### PR TITLE
Fix redirect to confirmation

### DIFF
--- a/src/main/webapp/availability.js
+++ b/src/main/webapp/availability.js
@@ -74,8 +74,8 @@ function selectTimeSlot(tutorID, window, timeslot) {
     var url = "scheduling.html?tutorID=" + encodeURIComponent(tutorID) +
                 "&start=" + encodeURIComponent(timeslot.start) +
                 "&end=" + encodeURIComponent(timeslot.end) +
-                "&year=" + encodeURIComponent(timeslot.year) +
-                "&month=" + encodeURIComponent(timeslot.month) +
-                "&day=" + encodeURIComponent(timeslot.day);
+                "&year=" + encodeURIComponent(timeslot.date.year) +
+                "&month=" + encodeURIComponent(timeslot.date.month) +
+                "&day=" + encodeURIComponent(timeslot.date.dayOfMonth);
     window.location.href = url;
 }

--- a/src/main/webapp/scheduling.js
+++ b/src/main/webapp/scheduling.js
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 function scheduleTutorSession() {
+    scheduleTutorSessionHelper(window);
+}
+
+function scheduleTutorSessionHelper(window) {
     var queryString = new Array();
     window.onload = readComponents(queryString, window);
     const tutorID = queryString["tutorID"];

--- a/src/main/webapp/webapptests/spec/SpecAvailability.js
+++ b/src/main/webapp/webapptests/spec/SpecAvailability.js
@@ -69,7 +69,7 @@ describe("Availability", function() {
 
     describe("when a user selects an available time slot", function() {
         var mockWindow = {location: {href: "availability.html"}};
-        var timeslot = {duration: 60, end: 540, start: 480, year: 2020, month: 5, day: 18};
+        var timeslot = {duration: 60, end: 540, start: 480, date: {year: 2020, month: 5, dayOfMonth: 18}};
 
         it("should redirect the user to scheduling.html and pass tutorID as an URI component", function() {
             selectTimeSlot("test@gmail.com", mockWindow, timeslot);

--- a/src/main/webapp/webapptests/spec/SpecScheduling.js
+++ b/src/main/webapp/webapptests/spec/SpecScheduling.js
@@ -14,25 +14,25 @@
 
 describe("Scheduling", function() {
     describe("when tutoring session is scheduled", function() {
-        var mockWindow = {location: {href: "scheduling.html?tutorID=test%40gmail.com&start=480&end=540&year=2020&month=5&day=18", search: "?tutorID=test%40gmail.com&start=480&end=540&year=2020&month=5&day=18"}};
+        var mockWindow = {location: {href: "scheduling.html?tutorID=elian%40google.com&start=480&end=540&year=2020&month=5&day=18", search: "?tutorID=elian%40google.com&start=480&end=540&year=2020&month=5&day=18"}};
 
         it("should trigger the fetch function", function() {
             spyOn(document, "getElementById").and.returnValue("");
             spyOn(window, 'fetch').and.callThrough();
 
-            scheduleTutorSession(mockWindow);
+            scheduleTutorSessionHelper(mockWindow);
 
             expect(window.fetch).toHaveBeenCalled();
         });
     });
 
     describe("when the URI components are read", function() {
-        var mockWindow = {location: {href: "scheduling.html?tutorID=test%40gmail.com&start=480&end=540&year=2020&month=5&day=18", search: "?tutorID=test%40gmail.com&start=480&end=540&year=2020&month=5&day=18"}};
+        var mockWindow = {location: {href: "scheduling.html?tutorID=thegoogler%40google.com&start=480&end=540&year=2020&month=5&day=18", search: "?tutorID=thegoogler%40google.com&start=480&end=540&year=2020&month=5&day=18"}};
         var queryString = new Array();
         readComponents(queryString, mockWindow);
 
         it("should add tutorID, start, end, year, month, and day to the query string", function() {
-            expect(queryString["tutorID"]).toEqual("test@gmail.com");
+            expect(queryString["tutorID"]).toEqual("thegoogler@gmail.com");
             expect(queryString["start"]).toEqual("480");
             expect(queryString["end"]).toEqual("540");
             expect(queryString["year"]).toEqual("2020");


### PR DESCRIPTION
The changes proposed in this PR fix the issue with the user being redirected to the confirmation page after scheduling a tutoring session. The issue was that the year, month, and day parameters were undefined because they were inside the date property of timeslot and were parameters of their own inside timeslot. Now, those parameters are accessed by accessing the date property inside timeslot. The scheduling servlet should now be able to run with no issues and the user will be redirected to confirmation.html.