### PR TITLE
Add time as a filter in history

### DIFF
--- a/src/main/java/com/google/sps/data/SampleData.java
+++ b/src/main/java/com/google/sps/data/SampleData.java
@@ -32,33 +32,40 @@ public final class SampleData {
     
     private static final Calendar MAY182020 = new Calendar.Builder()
                                                         .setCalendarType("iso8601")
-                                                        .setDate(2020, 5, 18)
+                                                        .setDate(2020, 4, 18)
                                                         .build();
-    private static final Calendar JUNE102020 = new Calendar.Builder()
+    private static final Calendar AUGUST102020 = new Calendar.Builder()
                                                         .setCalendarType("iso8601")
-                                                        .setDate(2020, 6, 10)
+                                                        .setDate(2020, 7, 10)
                                                         .build();
+
+    private static final Calendar AUGUST72020 = new Calendar.Builder()
+                                                        .setCalendarType("iso8601")
+                                                        .setDate(2020, 7, 7)
+                                                        .build();
+                                                        
 
     private static ArrayList<Tutor> tutors = new ArrayList<Tutor> (Arrays.asList(
         new Tutor("Kashish Arora", "kashisharora@google.com", new ArrayList<String> (Arrays.asList("Math", "History")),
                 new ArrayList<TimeRange> (Arrays.asList(TimeRange.fromStartToEnd(TIME_1200AM, TIME_0100PM, MAY182020),
-                            TimeRange.fromStartToEnd(TIME_0300PM,TIME_0500PM, JUNE102020))),
+                            TimeRange.fromStartToEnd(TIME_0300PM,TIME_0500PM, AUGUST102020))),
                 new ArrayList<TutorSession> (Arrays.asList())),
         new Tutor("Bernardo Eilert Trevisan", "btrevisan@google.com", new ArrayList<String> (Arrays.asList("English", "Physics")),
                 new ArrayList<TimeRange> (Arrays.asList(TimeRange.fromStartToEnd(TIME_0800AM, TIME_1000AM, MAY182020),
-                             TimeRange.fromStartToEnd(TIME_1100AM,TIME_0100PM, JUNE102020))),
+                             TimeRange.fromStartToEnd(TIME_1100AM,TIME_0100PM, AUGUST102020),
+                             TimeRange.fromStartToEnd(TIME_0100PM, TIME_0300PM, AUGUST72020))),
                 new ArrayList<TutorSession> (Arrays.asList())),
         new Tutor("Sam Falberg", "sfalberg@google.com", new ArrayList<String> (Arrays.asList("Geology", "English")),
                 new ArrayList<TimeRange> (Arrays.asList(TimeRange.fromStartToEnd(TIME_1000AM, TIME_1200AM, MAY182020),
-                            TimeRange.fromStartToEnd(TIME_0100PM,TIME_0200PM, JUNE102020))),
+                            TimeRange.fromStartToEnd(TIME_0100PM,TIME_0200PM, AUGUST102020))),
                 new ArrayList<TutorSession> (Arrays.asList())),
         new Tutor("Anand Desai", "thegoogler@google.com", new ArrayList<String> (Arrays.asList("Finance", "Chemistry")),
                 new ArrayList<TimeRange> (Arrays.asList(TimeRange.fromStartToEnd(TIME_1000AM, TIME_1200AM, MAY182020),
-                            TimeRange.fromStartToEnd(TIME_0100PM,TIME_0200PM, JUNE102020))),
+                            TimeRange.fromStartToEnd(TIME_0100PM,TIME_0200PM, AUGUST102020))),
                 new ArrayList<TutorSession> (Arrays.asList())),
         new Tutor("Elian Dumitru", "elian@google.com", new ArrayList<String> (Arrays.asList("Geology", "Math")),
                 new ArrayList<TimeRange> (Arrays.asList(TimeRange.fromStartToEnd(TIME_1000AM, TIME_1200AM, MAY182020),
-                            TimeRange.fromStartToEnd(TIME_0100PM,TIME_0200PM, JUNE102020))),
+                            TimeRange.fromStartToEnd(TIME_0100PM,TIME_0200PM, AUGUST102020))),
                 new ArrayList<TutorSession> (Arrays.asList()))
     ));
 

--- a/src/main/java/com/google/sps/servlets/ConfirmationServlet.java
+++ b/src/main/java/com/google/sps/servlets/ConfirmationServlet.java
@@ -25,6 +25,10 @@ import java.util.Optional;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Calendar;
+import java.util.Date;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -53,9 +57,36 @@ public class ConfirmationServlet extends HttpServlet {
             }
         }
 
-        String json = new Gson().toJson(scheduledSessions);
+        List<TutorSession> upcomingSessions = new ArrayList<TutorSession>();
+
+        filterUpcomingSessions(scheduledSessions, upcomingSessions);
+
+        String json = new Gson().toJson(upcomingSessions);
         response.setContentType("application/json;");
         response.getWriter().println(json);
         return;
     }
+
+    private void filterUpcomingSessions(List<TutorSession> allSessions, List<TutorSession> upcomingSessions) {
+        Date currentDate = new Date();
+
+        for (TutorSession session : allSessions) {
+            Calendar sessionCalendar = session.getTimeslot().getDate();
+            int start = session.getTimeslot().getStart();
+            int hour = start / 60;
+            int minute = start % 60;
+
+            sessionCalendar.set(Calendar.HOUR_OF_DAY, hour);
+            sessionCalendar.set(Calendar.MINUTE, minute);
+
+            Date sessionDate = sessionCalendar.getTime();
+            int comparison = currentDate.compareTo(sessionDate);
+            if (comparison == 0 || comparison == -1) {
+                    upcomingSessions.add(session);
+            }
+        }
+
+        return;
+    }
+
 }

--- a/src/main/java/com/google/sps/servlets/HistoryServlet.java
+++ b/src/main/java/com/google/sps/servlets/HistoryServlet.java
@@ -25,6 +25,8 @@ import java.util.Optional;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Date;
+import java.util.Calendar;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -53,9 +55,35 @@ public class HistoryServlet extends HttpServlet {
             }
         }
 
-        String json = new Gson().toJson(scheduledSessions);
+        List<TutorSession> previousSessions = new ArrayList<TutorSession>();
+
+        filterPastSessions(scheduledSessions, previousSessions);
+
+        String json = new Gson().toJson(previousSessions);
         response.setContentType("application/json;");
         response.getWriter().println(json);
+        return;
+    }
+
+    private void filterPastSessions(List<TutorSession> allSessions, List<TutorSession> previousSessions) {
+        Date currentDate = new Date();
+
+        for (TutorSession session : allSessions) {
+            Calendar sessionCalendar = session.getTimeslot().getDate();
+            int start = session.getTimeslot().getStart();
+            int hour = start / 60;
+            int minute = start % 60;
+
+            sessionCalendar.set(Calendar.HOUR_OF_DAY, hour);
+            sessionCalendar.set(Calendar.MINUTE, minute);
+
+            Date sessionDate = sessionCalendar.getTime();
+            int comparison = currentDate.compareTo(sessionDate);
+            if (comparison == 0 || comparison == 1) {
+                    previousSessions.add(session);
+            }
+        }
+
         return;
     }
 }

--- a/src/test/java/com/google/sps/ConfirmationTest.java
+++ b/src/test/java/com/google/sps/ConfirmationTest.java
@@ -16,6 +16,7 @@ package com.google.sps;
 
 import java.util.List;
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.io.StringWriter;
 import java.io.PrintWriter;
@@ -72,7 +73,7 @@ public final class ConfirmationTest {
         when(response.getWriter()).thenReturn(writer);
         when(request.getContentType()).thenReturn("application/json");
 
-        Calendar date = new Calendar.Builder().setCalendarType("iso8601").setDate(2020, 5, 18).build();
+        Calendar date = new Calendar.Builder().setCalendarType("iso8601").setDate(2020, 7, 18).build();
 
         TutorSession tutoringSessionFake = new TutorSession("sfalberg@google.com", "sfalberg@google.com", null, null, TimeRange.fromStartToEnd(540, 600, date));
         SampleData.addToStudentScheduledSessionsByEmail("sfalberg@google.com", tutoringSessionFake);
@@ -80,11 +81,10 @@ public final class ConfirmationTest {
         ConfirmationServlet servlet = new ConfirmationServlet();
         servlet.doPost(request, response);
 
-        String expected = new Gson().toJson(new TutorSession[]{tutoringSessionFake});
+        String expected = new Gson().toJson(new ArrayList<TutorSession> (Arrays.asList(tutoringSessionFake)));
 
         verify(request, times(1)).getParameter("studentEmail");
         writer.flush();
-        // If the user has no scheduled sessions, the return json string should be an empty array
         Assert.assertTrue(stringWriter.toString().contains(expected));
     }
 }

--- a/src/test/java/com/google/sps/HistoryTest.java
+++ b/src/test/java/com/google/sps/HistoryTest.java
@@ -17,6 +17,7 @@ package com.google.sps;
 import java.util.List;
 import java.util.Calendar;
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.io.StringWriter;
 import java.io.PrintWriter;
 import org.junit.Assert;
@@ -41,7 +42,7 @@ public final class HistoryTest {
 
     private static final Calendar MAY182020 = new Calendar.Builder()
                                                         .setCalendarType("iso8601")
-                                                        .setDate(2020, 5, 18)
+                                                        .setDate(2020, 4, 18)
                                                         .build();
 
     @Test
@@ -86,9 +87,9 @@ public final class HistoryTest {
         HistoryServlet servlet = new HistoryServlet();
         servlet.doPost(request, response);
 
-        String expected = new Gson().toJson(new TutorSession[]{tutoringSessionFake});
+        String expected = new Gson().toJson(new ArrayList<TutorSession> (Arrays.asList(tutoringSessionFake)));
 
-        verify(request, atLeast(1)).getParameter("studentEmail");
+        verify(request, times(1)).getParameter("studentEmail");
         writer.flush();
         // If the user has a tutoring session history, the return json string should reflect that history
         Assert.assertTrue(stringWriter.toString().contains(expected));

--- a/src/test/java/com/google/sps/RatingTest.java
+++ b/src/test/java/com/google/sps/RatingTest.java
@@ -44,7 +44,7 @@ public final class RatingTest {
 
     private static final Calendar MAY182020 = new Calendar.Builder()
                                                         .setCalendarType("iso8601")
-                                                        .setDate(2020, 5, 18)
+                                                        .setDate(2020, 4, 18)
                                                         .build();
 
     @Test

--- a/src/test/java/com/google/sps/SchedulingTest.java
+++ b/src/test/java/com/google/sps/SchedulingTest.java
@@ -43,11 +43,17 @@ import java.util.Arrays;
 public final class SchedulingTest {
     private static final Calendar MAY182020 = new Calendar.Builder()
                                                         .setCalendarType("iso8601")
-                                                        .setDate(2020, 5, 18)
+                                                        .setDate(2020, 4, 18)
                                                         .build();
-    private static final Calendar JUNE102020 = new Calendar.Builder()
+
+    private static final Calendar AUGUST102020 = new Calendar.Builder()
                                                         .setCalendarType("iso8601")
-                                                        .setDate(2020, 6, 10)
+                                                        .setDate(2020, 7, 10)
+                                                        .build();
+
+    private static final Calendar AUGUST72020 = new Calendar.Builder()
+                                                        .setCalendarType("iso8601")
+                                                        .setDate(2020, 7, 7)
                                                         .build();
 
     private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 00);
@@ -69,7 +75,7 @@ public final class SchedulingTest {
         when(request.getParameter("start")).thenReturn("480");
         when(request.getParameter("end")).thenReturn("600");
         when(request.getParameter("year")).thenReturn("2020");
-        when(request.getParameter("month")).thenReturn("5");
+        when(request.getParameter("month")).thenReturn("4");
         when(request.getParameter("day")).thenReturn("18");
         when(request.getParameter("studentEmail")).thenReturn("thegoogler@google.com");
         when(request.getParameter("subtopics")).thenReturn("algebra");
@@ -93,8 +99,6 @@ public final class SchedulingTest {
         verify(request, times(1)).getParameter("subtopics");
         verify(request, times(1)).getParameter("questions");
 
-        Calendar date = new Calendar.Builder().setCalendarType("iso8601").setDate(2020, 5, 18).build();
-
         String expected = new Gson()
                             .toJson(new TutorSession("thegoogler@google.com",
                                             "btrevisan@google.com",
@@ -106,7 +110,8 @@ public final class SchedulingTest {
                                             "btrevisan@google.com",
                                             new ArrayList<String> (Arrays.asList("English", "Physics")),
                                             new ArrayList<TimeRange> (Arrays.asList(TimeRange.fromStartToEnd(TIME_0800AM, TIME_1000AM, MAY182020),
-                                                        TimeRange.fromStartToEnd(TIME_1100AM,TIME_0100PM, JUNE102020))),
+                                                        TimeRange.fromStartToEnd(TIME_1100AM,TIME_0100PM, AUGUST102020),
+                                                        TimeRange.fromStartToEnd(TIME_0100PM, TIME_0300PM, AUGUST72020))),
                                             new ArrayList<TutorSession> (Arrays.asList())));
 
         writer.flush();

--- a/src/test/java/com/google/sps/SearchTest.java
+++ b/src/test/java/com/google/sps/SearchTest.java
@@ -45,11 +45,12 @@ public final class SearchTest {
     
     private static final Calendar MAY182020 = new Calendar.Builder()
                                                         .setCalendarType("iso8601")
-                                                        .setDate(2020, 5, 18)
+                                                        .setDate(2020, 4, 18)
                                                         .build();
-    private static final Calendar JUNE102020 = new Calendar.Builder()
+
+    private static final Calendar AUGUST102020 = new Calendar.Builder()
                                                         .setCalendarType("iso8601")
-                                                        .setDate(2020, 6, 10)
+                                                        .setDate(2020, 7, 10)
                                                         .build();
 
     private SearchServlet servlet;
@@ -76,11 +77,10 @@ public final class SearchTest {
         //verify that getParameter was called
         verify(request, times(1)).getParameter("topic"); 
         writer.flush(); // it may not have been flushed yet...
-        List<Tutor> expectedTutorList = Arrays.asList(new Tutor("Kashish Arora",
-                                                            "kashisharora@google.com",
+        List<Tutor> expectedTutorList = Arrays.asList(new Tutor("Kashish Arora", "kashisharora@google.com", 
                                                             new ArrayList<String> (Arrays.asList("Math", "History")),
                                                             new ArrayList<TimeRange> (Arrays.asList(TimeRange.fromStartToEnd(TIME_1200AM, TIME_0100PM, MAY182020),
-                                                                        TimeRange.fromStartToEnd(TIME_0300PM,TIME_0500PM, JUNE102020))),
+                                                                        TimeRange.fromStartToEnd(TIME_0300PM,TIME_0500PM, AUGUST102020))),
                                                             new ArrayList<TutorSession> (Arrays.asList())));
         String expected = new Gson().toJson(expectedTutorList);
         Assert.assertTrue(stringWriter.toString().contains(expected));


### PR DESCRIPTION
The commits proposed in this PR will filter the the tutoring sessions for the history page so that only previous tutoring sessions show up. The converse applies for the confirmation page; only upcoming sessions will show up in the confirmation page.