### PR TITLE
Store TimeRange and TutorSession entities with a tutor id

### DIFF
--- a/src/main/java/com/google/sps/servlets/RegistrationServlet.java
+++ b/src/main/java/com/google/sps/servlets/RegistrationServlet.java
@@ -86,9 +86,6 @@ public class RegistrationServlet extends HttpServlet {
     entity.setProperty("name", name);
     entity.setProperty("email", email);
     entity.setProperty("learning", topics);
-    //stores a list of TutorSession entity ids
-    entity.setProperty("scheduledSessions", new ArrayList<Long>());
-    entity.setProperty("topics", topics);
     entity.setProperty("userId", userId);
     ds.put(entity);
   }
@@ -99,11 +96,6 @@ public class RegistrationServlet extends HttpServlet {
   public void createTutorEntityAndPutInDatastore(DatastoreService ds, Entity entity, String name, String email, List<String> topics, String userId) {
     entity.setProperty("name", name);
     entity.setProperty("email", email);
-    entity.setProperty("topics", topics);
-    //stores a list of TimeRange entity ids
-    entity.setProperty("availability", new ArrayList<Long>());
-    //stores a list of TutorSession entity ids
-    entity.setProperty("scheduledSessions", new ArrayList<Long>());
     entity.setProperty("topics", topics);
     entity.setProperty("userId", userId);
     ds.put(entity);

--- a/src/main/java/com/google/sps/utilities/RealSearchDatastore.java
+++ b/src/main/java/com/google/sps/utilities/RealSearchDatastore.java
@@ -66,7 +66,7 @@ public final class RealSearchDatastore implements SearchDatastoreService {
                 String name = (String) tutorEntity.getProperty("name");
                 String email = (String) tutorEntity.getProperty("email");
                 ArrayList skills = (ArrayList) tutorEntity.getProperty("topics");
-                ArrayList<TimeRange> availability = getTimeRanges(datastore, id);
+                ArrayList<TimeRange> availability = getTimeRanges(datastore, txn, tutorEntity.getKey());
                 ArrayList<TutorSession> scheduledSessions = getScheduledSessions(datastore, txn, id);
 
                 Tutor tutor = new Tutor(name, email, skills, availability, scheduledSessions);
@@ -126,14 +126,12 @@ public final class RealSearchDatastore implements SearchDatastoreService {
     * Gets all the time range entities corresponding that have the given tutorId.
     * @return ArrayList<TimeRange>
     */
-    private ArrayList<TimeRange> getTimeRanges(DatastoreService datastore, long tutorId) {
+    private ArrayList<TimeRange> getTimeRanges(DatastoreService datastore, Transaction txn, Key tutorKey) {
         ArrayList<TimeRange> availability = new ArrayList<TimeRange>();
         
-        //get all time ranges with tutor id
-        Filter filter = new FilterPredicate("tutorId", FilterOperator.EQUAL, tutorId);
-        Query query = new Query("TimeRange").setFilter(filter);
-
-        PreparedQuery timeRanges = datastore.prepare(query);
+        //Use ancestor query to get all time ranges that belong to the tutor
+        Query query = new Query("TimeRange", tutorKey);
+        PreparedQuery timeRanges = datastore.prepare(txn, query);
 
         for(Entity time : timeRanges.asIterable()) {
             availability.add(createTimeRange(time));

--- a/src/main/java/com/google/sps/utilities/RealSearchDatastore.java
+++ b/src/main/java/com/google/sps/utilities/RealSearchDatastore.java
@@ -61,12 +61,13 @@ public final class RealSearchDatastore implements SearchDatastoreService {
             PreparedQuery tutorResults = datastore.prepare(tutorQuery);
 
             for (Entity tutorEntity : tutorResults.asIterable()) {
-
+                
+                long id = (long) tutorEntity.getKey().getId();
                 String name = (String) tutorEntity.getProperty("name");
                 String email = (String) tutorEntity.getProperty("email");
                 ArrayList skills = (ArrayList) tutorEntity.getProperty("topics");
-                ArrayList<TimeRange> availability = getTimeRanges(datastore, txn, (ArrayList) tutorEntity.getProperty("availability"));
-                ArrayList<TutorSession> scheduledSessions = getScheduledSessions(datastore, txn, (ArrayList) tutorEntity.getProperty("scheduledSessions"));
+                ArrayList<TimeRange> availability = getTimeRanges(datastore, id);
+                ArrayList<TutorSession> scheduledSessions = getScheduledSessions(datastore, txn, id);
 
                 Tutor tutor = new Tutor(name, email, skills, availability, scheduledSessions);
 
@@ -86,69 +87,66 @@ public final class RealSearchDatastore implements SearchDatastoreService {
     }
 
     /**
-    * Gets all the tutor session entities corresponding to the ids in sessionIds and creates TutorSession objects.
+    * Gets all the tutor session entities with the corresponding tutorId. 
     * @return ArrayList<TutorSession>
     */
-    private ArrayList<TutorSession> getScheduledSessions(DatastoreService datastore, Transaction txn, List<Long> sessionIds) {
+    private ArrayList<TutorSession> getScheduledSessions(DatastoreService datastore, Transaction txn, long tutorId) {
         ArrayList<TutorSession> sessions = new ArrayList<TutorSession>();
 
-        //datastore stores empty lists as null values, so if sessionIds is null, there are no scheduled sessions
-        if(sessionIds == null) {
-            return sessions;
-        }
+        //get all sessions with tutor id
+        Filter filter = new FilterPredicate("tutorId", FilterOperator.EQUAL, tutorId);
+        Query query = new Query("TutorSession").setFilter(filter);
 
-        for(Long id : sessionIds) {
-            Key tutorSessionKey = KeyFactory.createKey("TutorSession", id);
+        PreparedQuery sessionEntities = datastore.prepare(query);
 
+        for(Entity entity : sessionEntities.asIterable()) {
             try {
-                Entity entity = datastore.get(txn, tutorSessionKey);
+
                 String studentEmail = (String) entity.getProperty("studentEmail");
                 String tutorEmail = (String) entity.getProperty("tutorEmail");
                 String subtopics = (String) entity.getProperty("subtopics");
                 String questions = (String) entity.getProperty("questions");
-                TimeRange timeslot = getTimeRange(datastore, txn, (long) entity.getProperty("timeslot"));
+
+                Key timeRangeKey = KeyFactory.createKey("TimeRange", (long) entity.getProperty("timeslot"));
+                Entity timeEntity = datastore.get(txn, timeRangeKey); 
+                TimeRange timeslot = createTimeRange(timeEntity);
 
                 sessions.add(new TutorSession(studentEmail, tutorEmail, subtopics, questions, timeslot));
-            } catch (EntityNotFoundException e)  {
-                //The tutoring session doesn't exist, skip this id
+
+            } catch (EntityNotFoundException e) {
+                //timeslot was not found, skip this tutoring session
             }
+           
         }
 
         return sessions;
     }
 
     /**
-    * Gets all the time range entities corresponding to the ids in rangeIds and creates TimeRange objects.
+    * Gets all the time range entities corresponding that have the given tutorId.
     * @return ArrayList<TimeRange>
     */
-    private ArrayList<TimeRange> getTimeRanges(DatastoreService datastore, Transaction txn, List<Long> rangeIds) {
+    private ArrayList<TimeRange> getTimeRanges(DatastoreService datastore, long tutorId) {
         ArrayList<TimeRange> availability = new ArrayList<TimeRange>();
+        
+        //get all time ranges with tutor id
+        Filter filter = new FilterPredicate("tutorId", FilterOperator.EQUAL, tutorId);
+        Query query = new Query("TimeRange").setFilter(filter);
 
-        //datastore stores empty lists as null values, so if rangeIds is null, there are no available times
-        if(rangeIds == null) {
-            return availability;
-        }
+        PreparedQuery timeRanges = datastore.prepare(query);
 
-        for(Long id : rangeIds) {
-            try {
-                availability.add(getTimeRange(datastore, txn, id));
-            } catch (EntityNotFoundException e)  {
-                //The time range doesn't exist, skip this id
-            }
+        for(Entity time : timeRanges.asIterable()) {
+            availability.add(createTimeRange(time));
         }
 
         return availability;
     }
 
     /**
-    * Gets the time range entity corresponding to the id and creates a TimeRange object.
+    * Creates a TimeRange object from a given TimeRange entity.
     * @return TimeRange
     */
-    private TimeRange getTimeRange(DatastoreService datastore, Transaction txn, long id) throws EntityNotFoundException{
-
-        Key timeRangeKey = KeyFactory.createKey("TimeRange", id);
-
-        Entity entity = datastore.get(txn, timeRangeKey);
+    private TimeRange createTimeRange(Entity entity) {
         int start = Math.toIntExact((long) entity.getProperty("start"));
         int end = Math.toIntExact((long) entity.getProperty("end"));
         Calendar date = new Gson().fromJson((String) entity.getProperty("date"), Calendar.class);

--- a/src/main/java/com/google/sps/utilities/RealSearchDatastore.java
+++ b/src/main/java/com/google/sps/utilities/RealSearchDatastore.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Calendar;
 import com.google.gson.Gson;
 
-/** Accesses Datastore to implement the SearchDatastoreService methods. */
+/** Accesses Datastore to implement the SearchDatastoreService methods. */ 
 public final class RealSearchDatastore implements SearchDatastoreService {
 
     /**

--- a/src/test/java/com/google/sps/RegistrationTest.java
+++ b/src/test/java/com/google/sps/RegistrationTest.java
@@ -100,8 +100,6 @@ public final class RegistrationTest {
         Entity expectedTutor = new Entity("Tutor");
         expectedTutor.setProperty("name", "Sam F");
         expectedTutor.setProperty("email", USER_EMAIL);
-        expectedTutor.setProperty("availability", new ArrayList<Long>());
-        expectedTutor.setProperty("scheduledSessions", new ArrayList<Long>());
         expectedTutor.setProperty("topics", mockTopics);
         expectedTutor.setProperty("userId", USER_ID);
 


### PR DESCRIPTION
These commits remove the availability and tutor session fields from the tutor and student entities. Instead of storing a list of ids inside of the entity, a tutor id will be stored with the TimeRange and TutorSession entities. This makes it easier to add and delete time ranges and sessions because we won't have to keep updating the lists inside of the Tutor entity every time. Whenever we need to get the availability of a tutor, we can easily filter out TimeRange entities based on their tutor id or whenever we need to get a list of tutoring sessions, we can filter out TutorSession entities based on tutor or student id. 