### PR TITLE
Fix transition from scheduling to confirmation

### DIFF
--- a/src/main/webapp/scheduling.html
+++ b/src/main/webapp/scheduling.html
@@ -23,7 +23,7 @@
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
         <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     </head>
-    <body onload="displayLoginLogoutLink()">
+    <body onload="displayLoginLogoutLink(), addEventListeners()">
         <a href="./homepage.html"><p>Homepage</p></a>
 
         <div class="top-right">
@@ -39,7 +39,7 @@
         <div class="container-fluid">
             <h1>Last Step!</h1>
 
-            <form>
+            <form id="scheduling-form">
                 <div class="form-group">
                     <label for="studentEmail" class="col-sm-2 col-form-label">Email:</label>
                     <input type="text" class="form-control" name="studentEmail" id="studentEmail" style="color: #555555;" placeholder="Your email here..." required>
@@ -55,7 +55,7 @@
                     <textarea class="form-control" name="questions" id="questions" rows="3" placeholder="Any questions you might have..."></textarea>
                 </div>
 
-                <button type="submit" class="btn btn-primary" onclick="scheduleTutorSession()">Submit</button>
+                <button type="submit" class="btn btn-primary">Submit</button>
             </form>
         </div>
 

--- a/src/main/webapp/scheduling.js
+++ b/src/main/webapp/scheduling.js
@@ -12,49 +12,53 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-function scheduleTutorSession() {
-    scheduleTutorSessionHelper(window);
+/** A function that adds event listeners to a DOM objects. */
+function addEventListeners() {
+    document.getElementById("scheduling-form").addEventListener('submit', event => {
+        event.preventDefault();
+        scheduleTutorSession(window);
+    });
 }
 
-function scheduleTutorSessionHelper(window) {
+
+function scheduleTutorSession(window) {
     getUserId().then(function(studentID) {
-        var queryString = new Array();
-        window.onload = readComponents(queryString, window);
-        const tutorID = queryString["tutorID"];
-        const start = queryString["start"];
-        const end = queryString["end"];
-        const year = queryString["year"];
-        const month = queryString["month"];
-        const day = queryString["day"];
-
-        var subtopics = document.getElementById("topics").value;
-        var questions = document.getElementById("questions").value;
-
-        const params = new URLSearchParams();
-        params.append('tutorID', tutorID);
-        params.append('start', start);
-        params.append('end', end);
-        params.append('year', year);
-        params.append('month', month);
-        params.append('day', day);
-        params.append('studentID', studentID);
-        params.append('subtopics', subtopics);
-        params.append('questions', questions);
-
-        // Redirect user to confirmation
-        fetch('/scheduling', {method: 'POST', body: params}).then(response => response.json()).then((tutors) => {
-            if(tutors.error) {
-                var message = document.createElement("p");
-                message.innerText = tutors.error;
-                document.body.appendChild(message);
-                return;
-            }
-
-            redirectToConfirmation(studentID, window);
-        });
-
+        scheduleTutorSessionHelper(window, studentID);
     });
+}
 
+function scheduleTutorSessionHelper(window, studentID) {
+    var queryString = new Array();
+    window.onload = readComponents(queryString, window);
+    const tutorID = queryString["tutorID"];
+    const start = queryString["start"];
+    const end = queryString["end"];
+    const year = queryString["year"];
+    const month = queryString["month"];
+    const day = queryString["day"];
+
+    const params = new URLSearchParams();
+    params.append('tutorID', tutorID);
+    params.append('start', start);
+    params.append('end', end);
+    params.append('year', year);
+    params.append('month', month);
+    params.append('day', day);
+    params.append('studentID', studentID);
+    params.append('subtopics', document.getElementById("topics").value);
+    params.append('questions', document.getElementById("questions").value);
+
+    // Redirect user to confirmation
+    fetch('/scheduling', {method: 'POST', body: params}).then(response => response.json()).then((tutors) => {
+        if(tutors.error) {
+            var message = document.createElement("p");
+            message.innerText = tutors.error;
+            document.body.appendChild(message);
+            return;
+        }
+
+        redirectToConfirmation(studentID, window);
+    });    
 }
 
 // Referenced to https://www.aspsnippets.com/Articles/Redirect-to-another-Page-on-Button-Click-using-JavaScript.aspx#:~:text=Redirecting%

--- a/src/main/webapp/webapptests/spec/SpecProgress.js
+++ b/src/main/webapp/webapptests/spec/SpecProgress.js
@@ -70,7 +70,7 @@ describe("Progress", function() {
             });
             spyOn(window, 'fetch').and.returnValue(Promise.resolve({json: () => Promise.resolve()}));
             getExperiences(document, mockLoginStatus, mockWindow);
-            expect(window.fetch).toHaveBeenCalledWith('/add-experience?studentID=undefined', {method: 'GET'});
+            expect(window.fetch).toHaveBeenCalledWith('/experience?studentID=undefined', {method: 'GET'});
             expect(document.getElementById('experiences-form').style.display).toBe('block');
         });
 
@@ -83,7 +83,7 @@ describe("Progress", function() {
             });
             spyOn(window, 'fetch').and.returnValue(Promise.resolve({json: () => Promise.resolve()}));
             getExperiences(document, mockLoginStatus, mockWindow);
-            expect(window.fetch).toHaveBeenCalledWith('/add-experience?studentID=undefined', {method: 'GET'});
+            expect(window.fetch).toHaveBeenCalledWith('/experience?studentID=undefined', {method: 'GET'});
             expect(document.getElementById('experiences-form').style.display).toBe('none');
         });
     });
@@ -140,7 +140,7 @@ describe("Progress", function() {
             });
             spyOn(window, 'fetch').and.returnValue(Promise.resolve({json: () => Promise.resolve()}));
             getGoals(document, mockLoginStatus, mockWindow);
-            expect(window.fetch).toHaveBeenCalledWith('/add-goal?studentID=undefined', {method: 'GET'});
+            expect(window.fetch).toHaveBeenCalledWith('/goal?studentID=undefined', {method: 'GET'});
             expect(document.getElementById('goals-form').style.display).toBe('block');
         });
 
@@ -153,7 +153,7 @@ describe("Progress", function() {
             });
             spyOn(window, 'fetch').and.returnValue(Promise.resolve({json: () => Promise.resolve()}));
             getGoals(document, mockLoginStatus, mockWindow);
-            expect(window.fetch).toHaveBeenCalledWith('/add-goal?studentID=undefined', {method: 'GET'});
+            expect(window.fetch).toHaveBeenCalledWith('/goal?studentID=undefined', {method: 'GET'});
             expect(document.getElementById('goals-form').style.display).toBe('none');
         });
     });
@@ -415,7 +415,7 @@ describe("Progress", function() {
             spyOn(window, 'fetch').and.callThrough();
             spyOn(document, 'getElementById').and.returnValue("test");
             addGoal(mockWindow);
-            expect(window.fetch).toHaveBeenCalledWith('/add-goal', {method: 'POST', body: params});
+            expect(window.fetch).toHaveBeenCalledWith('/goal', {method: 'POST', body: params});
         });
     });
 
@@ -433,7 +433,7 @@ describe("Progress", function() {
             spyOn(window, 'fetch').and.callThrough();
             spyOn(document, 'getElementById').and.returnValue("test");
             addExperience(mockWindow);
-            expect(window.fetch).toHaveBeenCalledWith('/add-experience', {method: 'POST', body: params});
+            expect(window.fetch).toHaveBeenCalledWith('/experience', {method: 'POST', body: params});
         });
     });
 


### PR DESCRIPTION
The commits proposed in this PR fix the transition from scheduling to confirmation. Previously, sometimes the user would not be redirected to the confirmation page because the event of clicking on the submit button to schedule a session would refresh the page before the scheduling servlet was done scheduling. This means that the user would only be redirected to confirmation if the scheduling servlet finished before the event refreshed the scheduling page. The fix was to prevent the default behavior of the event and manually redirect to confirmation only after scheduling is done.