### PR TITLE
Use sessions and servlet filters to prevent users from viewing other user's pages

### DIFF
--- a/src/main/java/com/google/sps/filters/SessionFilter.java
+++ b/src/main/java/com/google/sps/filters/SessionFilter.java
@@ -32,12 +32,16 @@ import java.util.Optional;
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
 
-/** Servlet filter that checks if the user has valid session to make a request. */
+/** Servlet filter that checks if the user has valid session to make a request.*/
 public class SessionFilter implements Filter {
 
     private ServletContext context;
     private FilterConfig filterConfig;
 
+    /**
+    * This method is called automatically before the request is sent to the servlet (specified in the web.xml file) to make sure
+    * the session is valid.
+    */
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
 
         HttpServletRequest req = (HttpServletRequest) request;

--- a/src/main/java/com/google/sps/filters/SessionFilter.java
+++ b/src/main/java/com/google/sps/filters/SessionFilter.java
@@ -62,7 +62,6 @@ public class SessionFilter implements Filter {
 
         //user has not logged in, no cookies have been created
         if(cookies == null) {
-            System.out.println("wrong 1");
             this.context.log("Unauthorized access request");
             return false;
         }
@@ -80,7 +79,6 @@ public class SessionFilter implements Filter {
 
         //The sessionId from the cookie has ".node0" as a suffix
         if(session == null || !(session.getId()+".node0").equals(sessionId)) {
-            System.out.println("wrong 2");
             this.context.log("Unauthorized access request");
 			
             return false;

--- a/src/main/java/com/google/sps/filters/SessionFilter.java
+++ b/src/main/java/com/google/sps/filters/SessionFilter.java
@@ -1,0 +1,103 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.filters;
+ 
+import java.io.IOException;
+import java.util.logging.Logger;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.Cookie;
+import javax.servlet.ServletContext;
+import java.util.stream.*;
+import java.util.Optional;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+
+/** Servlet filter that checks if the user has valid session to make a request. */
+public class SessionFilter implements Filter {
+
+    private ServletContext context;
+    private FilterConfig filterConfig;
+
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+
+        HttpServletRequest req = (HttpServletRequest) request;
+		HttpServletResponse resp = (HttpServletResponse) response;
+
+        if(userHasPermissions(req, resp)) {
+            filterChain.doFilter(request, response);
+        } else {
+            resp.sendRedirect("/homepage.html");
+            return;
+        }
+
+    }
+
+    /**
+    * Determines if the user has the right permissions to make the request based on their session id.
+    * @return boolean
+    */
+    public boolean userHasPermissions(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+
+        Cookie[] cookies = request.getCookies();
+
+        //user has not logged in, no cookies have been created
+        if(cookies == null) {
+            System.out.println("wrong 1");
+            this.context.log("Unauthorized access request");
+            return false;
+        }
+
+        String sessionId = "";
+        
+        for(Cookie cookie : cookies) {
+            if(cookie.getName().equals("JSESSIONID")) {
+                sessionId = cookie.getValue();
+                break;
+            }
+        }
+    
+        HttpSession session = request.getSession(false);
+
+        //The sessionId from the cookie has ".node0" as a suffix
+        if(session == null || !(session.getId()+".node0").equals(sessionId)) {
+            System.out.println("wrong 2");
+            this.context.log("Unauthorized access request");
+			
+            return false;
+        }
+
+        return true;
+    }
+
+    public FilterConfig getFilterConfig() {
+        return filterConfig;
+    }
+
+    public void init(FilterConfig filterConfig) {
+        this.filterConfig = filterConfig;
+        this.context = filterConfig.getServletContext();
+		this.context.log("SessionFilter initialized");
+    }
+
+    public void destroy() {}
+}

--- a/src/main/java/com/google/sps/servlets/AddAvailabilityServlet.java
+++ b/src/main/java/com/google/sps/servlets/AddAvailabilityServlet.java
@@ -73,7 +73,6 @@ public class AddAvailabilityServlet extends HttpServlet {
 
         String json = new Gson().toJson(datastore.getAvailabilityForTutor(tutorID));
         response.getWriter().println(json);
-        response.sendRedirect("/manage-availability.html?userID=" + tutorID);
         return;
     }
 }

--- a/src/main/java/com/google/sps/servlets/AddAvailabilityServlet.java
+++ b/src/main/java/com/google/sps/servlets/AddAvailabilityServlet.java
@@ -40,15 +40,11 @@ public class AddAvailabilityServlet extends HttpServlet {
     }
 
     @Override
-    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        response.setContentType("plain/text");
-        response.getWriter().println("To be implemented");
-    }
-
-    @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        response.setContentType("application/json");
+
         //Set default value to -1 
-        String tutorID = Optional.ofNullable(request.getParameter("tutorID")).orElse("-1");
+        String tutorID = Optional.ofNullable((String)request.getSession(false).getAttribute("userId")).orElse("-1");
         String startHour = request.getParameter("startHour");
         String startMinute = request.getParameter("startMinute");
         String endHour = request.getParameter("endHour");
@@ -61,7 +57,6 @@ public class AddAvailabilityServlet extends HttpServlet {
         int end = Integer.parseInt(endHour) * 60 + Integer.parseInt(endMinute);
 
         if(tutorID.equals("-1")) {
-            response.setContentType("application/json");
             response.getWriter().println("{\"error\": \"There was an error adding availability.\"}");
             return;
         }
@@ -77,7 +72,6 @@ public class AddAvailabilityServlet extends HttpServlet {
         datastore.addAvailability(tutorID, timeslot);
 
         String json = new Gson().toJson(datastore.getAvailabilityForTutor(tutorID));
-        response.setContentType("application/json;");
         response.getWriter().println(json);
         response.sendRedirect("/manage-availability.html?userID=" + tutorID);
         return;

--- a/src/main/java/com/google/sps/servlets/ConfirmationServlet.java
+++ b/src/main/java/com/google/sps/servlets/ConfirmationServlet.java
@@ -48,7 +48,7 @@ public class ConfirmationServlet extends HttpServlet {
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
         // Get the id of the student whose availability will be displayed.
         // if the parameter is null, make the default id -1, so 0 sessions are returned
-        String studentID = Optional.ofNullable(request.getParameter("studentID")).orElse("-1");
+        String studentID = Optional.ofNullable((String)request.getSession(false).getAttribute("userId")).orElse("-1");
 
         if(studentID.equals("-1")) {
             response.setContentType("application/json");

--- a/src/main/java/com/google/sps/servlets/DeleteAvailabilityServlet.java
+++ b/src/main/java/com/google/sps/servlets/DeleteAvailabilityServlet.java
@@ -48,7 +48,7 @@ public class DeleteAvailabilityServlet extends HttpServlet {
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         //if parameter is null, make the default id -1 so nothing gets deleted because there is no tutor with id = -1
-        String tutorID = Optional.ofNullable(request.getParameter("tutorID")).orElse("-1");
+        String tutorID = Optional.ofNullable((String)request.getSession(false).getAttribute("userId")).orElse("-1");
         String year = request.getParameter("year");
         String month = request.getParameter("month");
         String day = request.getParameter("day");

--- a/src/main/java/com/google/sps/servlets/DeleteExperienceServlet.java
+++ b/src/main/java/com/google/sps/servlets/DeleteExperienceServlet.java
@@ -43,7 +43,7 @@ public class DeleteExperienceServlet extends HttpServlet {
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         //Set default value to -1 
-        String studentID = Optional.ofNullable(request.getParameter("studentID")).orElse("-1");
+        String studentID = Optional.ofNullable((String)request.getSession(false).getAttribute("userId")).orElse("-1");
         long id = Long.parseLong(request.getParameter("id"));
 
         if(studentID.equals("-1")) {

--- a/src/main/java/com/google/sps/servlets/DeleteGoalServlet.java
+++ b/src/main/java/com/google/sps/servlets/DeleteGoalServlet.java
@@ -43,7 +43,7 @@ public class DeleteGoalServlet extends HttpServlet {
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         //Set default value to -1 
-        String studentID = Optional.ofNullable(request.getParameter("studentID")).orElse("-1");
+        String studentID = Optional.ofNullable((String)request.getSession(false).getAttribute("userId")).orElse("-1");
         long id = Long.parseLong(request.getParameter("id"));
 
         if(studentID.equals("-1")) {

--- a/src/main/java/com/google/sps/servlets/DeleteTutorSessionServlet.java
+++ b/src/main/java/com/google/sps/servlets/DeleteTutorSessionServlet.java
@@ -41,7 +41,7 @@ public class DeleteTutorSessionServlet extends HttpServlet {
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         String tutorID = request.getParameter("tutorID");
-        String studentID = request.getParameter("studentID");
+        String studentID = (String)request.getSession(false).getAttribute("userId");
         String year = request.getParameter("year");
         String month = request.getParameter("month");
         String day = request.getParameter("day");

--- a/src/main/java/com/google/sps/servlets/DeleteTutorSessionServlet.java
+++ b/src/main/java/com/google/sps/servlets/DeleteTutorSessionServlet.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Calendar;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -40,33 +41,13 @@ public class DeleteTutorSessionServlet extends HttpServlet {
 
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        String tutorID = request.getParameter("tutorID");
-        String studentID = (String)request.getSession(false).getAttribute("userId");
-        String year = request.getParameter("year");
-        String month = request.getParameter("month");
-        String day = request.getParameter("day");
-        String start = request.getParameter("start");
-        String end = request.getParameter("end");
-        String subtopics = request.getParameter("subtopics");
-        String questions = request.getParameter("questions");
-        String rating = request.getParameter("rating");
-        String id = request.getParameter("id");
-
-        Calendar date = new Calendar.Builder()
-                                .setCalendarType("iso8601")
-                                .setDate(Integer.parseInt(year), Integer.parseInt(month), Integer.parseInt(day))
-                                .build();
-
-        TimeRange timeslot = TimeRange.fromStartToEnd(Integer.parseInt(start), Integer.parseInt(end), date);
-
-        TutorSession session = new TutorSession(studentID, tutorID, subtopics, questions, timeslot, Integer.parseInt(rating), Long.parseLong(id));
-
-        
+        String studentID = Optional.ofNullable((String)request.getSession(false).getAttribute("userId")).orElse("-1");
+        long id = Long.parseLong(request.getParameter("id"));
 
         // Remove tutor session
-        datastore.deleteTutorSession(session);
+        datastore.deleteTutorSession(studentID, id);
 
-        String json = new Gson().toJson(datastore.getScheduledSessionsForStudent(studentID));
+        String json = new Gson().toJson(datastore.getScheduledSession(id));
         response.setContentType("application/json;");
         response.getWriter().println(json);
         return;

--- a/src/main/java/com/google/sps/servlets/ExperienceServlet.java
+++ b/src/main/java/com/google/sps/servlets/ExperienceServlet.java
@@ -62,7 +62,7 @@ public class ExperienceServlet extends HttpServlet {
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         //Set default value to -1 
-        String studentID = Optional.ofNullable(request.getParameter("studentID")).orElse("-1");
+        String studentID = Optional.ofNullable((String)request.getSession(false).getAttribute("userId")).orElse("-1");
         String experience = request.getParameter("experience");
 
         if(studentID.equals("-1")) {

--- a/src/main/java/com/google/sps/servlets/GetStudentsServlet.java
+++ b/src/main/java/com/google/sps/servlets/GetStudentsServlet.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.ArrayList;
 import java.lang.String;
 import com.google.gson.Gson;
+import java.util.Optional;
 import com.google.sps.utilities.StudentDatastoreService;
 
 /** Servlet that returns a list of students for a given tutor. */
@@ -39,16 +40,17 @@ public class GetStudentsServlet extends HttpServlet {
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        String tutorId = request.getParameter("tutorID");
+        //Set default value to -1 
+        String tutorID = Optional.ofNullable((String)request.getSession(false).getAttribute("userId")).orElse("-1");
         response.setContentType("application/json;");
 
-        //send error message if the search was invalid
-        if(tutorId == null || tutorId.equals("")) {
+        //send error message if the tutor id is invalid
+        if(tutorID == null || tutorID.equals("")) {
             response.getWriter().println("{\"error\": \"Invalid tutor.\"}");
             return;
         }
 
-        List<Student> students = datastore.getStudentsForTutor(tutorId);
+        List<Student> students = datastore.getStudentsForTutor(tutorID);
         
         String json = new Gson().toJson(students);
         response.getWriter().println(json);

--- a/src/main/java/com/google/sps/servlets/GoalServlet.java
+++ b/src/main/java/com/google/sps/servlets/GoalServlet.java
@@ -62,7 +62,7 @@ public class GoalServlet extends HttpServlet {
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         //Set default value to -1 
-        String studentID = Optional.ofNullable(request.getParameter("studentID")).orElse("-1");
+        String studentID = Optional.ofNullable((String)request.getSession(false).getAttribute("userId")).orElse("-1");
         String goal = request.getParameter("goal");
 
         if(studentID.equals("-1")) {

--- a/src/main/java/com/google/sps/servlets/HistoryServlet.java
+++ b/src/main/java/com/google/sps/servlets/HistoryServlet.java
@@ -47,7 +47,7 @@ public class HistoryServlet extends HttpServlet {
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
         // Get the id of the student whose tutoring history will be displayed.
         // Make the default id -1 if the parameter is null, so an empty list will be returned
-        String studentID = Optional.ofNullable(request.getParameter("studentID")).orElse("-1");
+        String studentID = Optional.ofNullable((String)request.getSession(false).getAttribute("userId")).orElse("-1");
 
         if(studentID.equals("-1")) {
             response.setContentType("application/json");

--- a/src/main/java/com/google/sps/servlets/LoginStatusServlet.java
+++ b/src/main/java/com/google/sps/servlets/LoginStatusServlet.java
@@ -28,6 +28,7 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 
 /** Servlet that gets the login status of the user and displays appropriate form */
 @WebServlet("/login-status")
@@ -39,12 +40,20 @@ public class LoginStatusServlet extends HttpServlet {
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
         // If user not logged in, show login form
         if (!userService.isUserLoggedIn()) {
+            if(request.getSession(false) != null) {
+                request.getSession(false).invalidate();
+            }
             LoginStatus loginStatus = new LoginStatus(false, false, userService.createLoginURL("/registration.html"), null);
             String json = new Gson().toJson(loginStatus);
             response.setContentType("application/json");
             response.getWriter().println(json);
             return;
         } 
+
+        if(request.getSession(false) == null) {
+            HttpSession session = request.getSession(true);
+            session.setAttribute("userId", userService.getCurrentUser().getUserId());
+        }
         
         String name = getName(userService.getCurrentUser().getUserId(), datastore);
         setRegistered(request, response, name);

--- a/src/main/java/com/google/sps/servlets/LogoutServlet.java
+++ b/src/main/java/com/google/sps/servlets/LogoutServlet.java
@@ -1,0 +1,36 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import com.google.appengine.api.datastore.*;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+/** Servlet that invalidates the user's session after they log out. */
+@WebServlet("/logout")
+public class LogoutServlet extends HttpServlet {
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        if(request.getSession(false) != null) {
+            request.getSession(false).invalidate();
+        }
+    }
+
+}

--- a/src/main/java/com/google/sps/servlets/RatingServlet.java
+++ b/src/main/java/com/google/sps/servlets/RatingServlet.java
@@ -49,7 +49,7 @@ public class RatingServlet extends HttpServlet {
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         //Make the default ids -1 because no student or tutor has id = -1 --> no session will get rated
         String tutorID = Optional.ofNullable(request.getParameter("tutorID")).orElse("-1");
-        String studentID = Optional.ofNullable(request.getParameter("studentID")).orElse("-1");
+        String studentID = Optional.ofNullable((String)request.getSession(false).getAttribute("userId")).orElse("-1");
         long sessionId = Long.parseLong(request.getParameter("sessionId"));
         int rating = Integer.parseInt(request.getParameter("rating"));
         

--- a/src/main/java/com/google/sps/servlets/RatingServlet.java
+++ b/src/main/java/com/google/sps/servlets/RatingServlet.java
@@ -40,31 +40,20 @@ public class RatingServlet extends HttpServlet {
     }
 
     @Override
-    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        response.setContentType("plain/text");
-        response.getWriter().println("To be implemented");
-    }
-
-    @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        //Make the default ids -1 because no student or tutor has id = -1 --> no session will get rated
-        String tutorID = Optional.ofNullable(request.getParameter("tutorID")).orElse("-1");
         String studentID = Optional.ofNullable((String)request.getSession(false).getAttribute("userId")).orElse("-1");
         long sessionId = Long.parseLong(request.getParameter("sessionId"));
         int rating = Integer.parseInt(request.getParameter("rating"));
         
-        boolean rated = datastore.rateTutorSession(sessionId, rating);
+        boolean rated = datastore.rateTutorSession(sessionId, studentID, rating);
 
         //rating was not successful
         if(!rated) {
             response.setContentType("application/json");
             response.getWriter().println("{\"error\": \"There was an error rating this session.\"}");
         }
-        
-        String jsonTutors = new Gson().toJson(datastore.getScheduledSessionsForTutor(tutorID));
-        String jsonStudents = new Gson().toJson(datastore.getScheduledSessionsForStudent(studentID));
 
-        String json = new Gson().toJson(new String[]{jsonTutors, jsonStudents}); 
+        String json = new Gson().toJson(datastore.getScheduledSession(sessionId)); 
         response.setContentType("application/json;");
         response.getWriter().println(json);
         response.sendRedirect("/history.html");

--- a/src/main/java/com/google/sps/servlets/SchedulingServlet.java
+++ b/src/main/java/com/google/sps/servlets/SchedulingServlet.java
@@ -41,12 +41,6 @@ public class SchedulingServlet extends HttpServlet {
     }
 
     @Override
-    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        response.setContentType("plain/text");
-        response.getWriter().println("To be implemented");
-    }
-
-    @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         response.setContentType("application/json;");
 

--- a/src/main/java/com/google/sps/servlets/SchedulingServlet.java
+++ b/src/main/java/com/google/sps/servlets/SchedulingServlet.java
@@ -52,7 +52,7 @@ public class SchedulingServlet extends HttpServlet {
 
         //make the default value -1 if ids were null
         String tutorID = Optional.ofNullable(request.getParameter("tutorID")).orElse("-1");
-        String studentID = Optional.ofNullable(request.getParameter("studentID")).orElse("-1");
+        String studentID = Optional.ofNullable((String)request.getSession(false).getAttribute("userId")).orElse("-1");
         String start = request.getParameter("start");
         String end = request.getParameter("end");
         String year = request.getParameter("year");

--- a/src/main/java/com/google/sps/utilities/StudentDatastoreService.java
+++ b/src/main/java/com/google/sps/utilities/StudentDatastoreService.java
@@ -63,6 +63,10 @@ public final class StudentDatastoreService {
                     String email = (String) studentEntity.getProperty("email");
                     ArrayList learning = (ArrayList) studentEntity.getProperty("learning");
 
+                    if(learning == null) {
+                        learning = new ArrayList<String>();
+                    }
+
                     Student student = new Student(name, bio, pfp, email, learning, tutors, studentId);
 
                     students.add(student);

--- a/src/main/java/com/google/sps/utilities/TutorSessionDatastoreService.java
+++ b/src/main/java/com/google/sps/utilities/TutorSessionDatastoreService.java
@@ -200,9 +200,6 @@ public final class TutorSessionDatastoreService {
 
         Entity studentEntity = pq.asSingleEntity();
 
-        System.out.println(studentEntity);
-        System.out.println(studentId);
-
         List<String> tutors = (List<String>) studentEntity.getProperty("tutors");
         if (tutors == null) {
             tutors = new ArrayList<String>();

--- a/src/main/java/com/google/sps/utilities/TutorSessionDatastoreService.java
+++ b/src/main/java/com/google/sps/utilities/TutorSessionDatastoreService.java
@@ -34,6 +34,7 @@ import com.google.appengine.api.datastore.Query.CompositeFilter;
 import java.lang.String;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Objects;
 import java.util.Calendar;
 import com.google.gson.Gson;
 
@@ -288,7 +289,7 @@ public final class TutorSessionDatastoreService {
         Entity timeEntity = pq.asSingleEntity();
         //change the tutorID property to the sessionId
         //instead of deleting the TimeRange entity, we can just set the tutorID property to the sessionId to indicate that it is a scheduled session 
-        timeEntity.setProperty("tutorID", sessionId);
+        timeEntity.setProperty("tutorID", String.valueOf(sessionId));
 
         //update in datastore
         datastore.put(txn, timeEntity);
@@ -301,7 +302,8 @@ public final class TutorSessionDatastoreService {
     * @return long, the id of the TimeRange entity
     */
     private long updateTimeRangeToAvailable(long sessionId, String tutorID, DatastoreService datastore, Transaction txn) {
-        //filter by tutor's email and time range properties
+
+        //filter by session id
         Filter timeFilter = new FilterPredicate("tutorID", FilterOperator.EQUAL, String.valueOf(sessionId));
 
         Query query = new Query("TimeRange").setFilter(timeFilter);
@@ -310,15 +312,14 @@ public final class TutorSessionDatastoreService {
 
         //there should only be one result
         Entity timeEntity = pq.asSingleEntity();
-        System.out.println(timeEntity);
 
-        //change the email property from "scheduled" to the tutor's email
+        //change the tutorID property back to the tutor the time range was owned by before
         timeEntity.setProperty("tutorID", tutorID);
 
         //update in datastore
         datastore.put(txn, timeEntity);
 
-        return timeEntity.getKey().getId();
+        return (long) timeEntity.getKey().getId();
     }
 
 }

--- a/src/main/java/com/google/sps/utilities/TutorSessionDatastoreService.java
+++ b/src/main/java/com/google/sps/utilities/TutorSessionDatastoreService.java
@@ -58,7 +58,11 @@ public final class TutorSessionDatastoreService {
             sessionEntity.setProperty("questions", session.getQuestions());
             sessionEntity.setProperty("rated", session.isRated());
             sessionEntity.setProperty("rating", session.getRating());
-            sessionEntity.setProperty("timeslot", updateTimeRangeToScheduled(session.getTutorID(), session.getTimeslot(), (long) sessionEntity.getKey().getId(), datastore, txn));
+    
+            datastore.put(txn, sessionEntity);
+
+            long timeslotId = updateTimeRangeToScheduled(session.getTutorID(), session.getTimeslot(), (long) sessionEntity.getKey().getId(), datastore, txn);
+            sessionEntity.setProperty("timeslot", timeslotId);
 
             datastore.put(txn, sessionEntity);
 
@@ -242,7 +246,6 @@ public final class TutorSessionDatastoreService {
             String subtopics = (String) entity.getProperty("subtopics");
             String questions = (String) entity.getProperty("questions");
             int rating = Math.toIntExact((long) entity.getProperty("rating"));
-
             Key timeRangeKey = KeyFactory.createKey("TimeRange", (long) entity.getProperty("timeslot"));
             Entity timeEntity = datastore.get(timeRangeKey); 
             TimeRange timeslot = createTimeRange(timeEntity);
@@ -283,7 +286,6 @@ public final class TutorSessionDatastoreService {
 
         //there should only be one result
         Entity timeEntity = pq.asSingleEntity();
-
         //change the tutorID property to the sessionId
         //instead of deleting the TimeRange entity, we can just set the tutorID property to the sessionId to indicate that it is a scheduled session 
         timeEntity.setProperty("tutorID", sessionId);
@@ -291,7 +293,7 @@ public final class TutorSessionDatastoreService {
         //update in datastore
         datastore.put(txn, timeEntity);
 
-        return timeEntity.getKey().getId();
+        return (long) timeEntity.getKey().getId();
     }
 
     /**
@@ -308,6 +310,7 @@ public final class TutorSessionDatastoreService {
 
         //there should only be one result
         Entity timeEntity = pq.asSingleEntity();
+        System.out.println(timeEntity);
 
         //change the email property from "scheduled" to the tutor's email
         timeEntity.setProperty("tutorID", tutorID);

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -3,10 +3,21 @@
          xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
          http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
          version="3.1">
-    <!-- <servlet>
-        <servlet-name>comingsoon</servlet-name>
-        <servlet-class>mysite.server.ComingSoonServlet</servlet-class>
-    </servlet> -->
+    <filter>
+        <filter-name>SessionFilter</filter-name>
+        <filter-class>com.google.sps.filters.SessionFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>SessionFilter</filter-name>
+        <url-pattern>add-availability</url-pattern>
+        <url-pattern>confirmation</url-pattern>
+        <url-pattern>delete-availability</url-pattern>
+        <url-pattern>delete-tutor-session</url-pattern>
+        <url-pattern>history</url-pattern>
+        <url-pattern>rating</url-pattern>
+        <url-pattern>registration</url-pattern>
+        <url-pattern>scheduling</url-pattern>
+    </filter-mapping>
     <security-constraint>
         <web-resource-collection>
             <url-pattern>/history.html</url-pattern>
@@ -55,14 +66,4 @@
             <role-name>*</role-name>
         </auth-constraint>
     </security-constraint>
-
-    <!-- <security-constraint>
-        <web-resource-collection>
-            <web-resource-name>admin</web-resource-name>
-            <url-pattern>/admin/*</url-pattern>
-        </web-resource-collection>
-        <auth-constraint>
-            <role-name>admin</role-name>
-        </auth-constraint>
-    </security-constraint> -->
 </web-app>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -12,8 +12,11 @@
         <url-pattern>add-availability</url-pattern>
         <url-pattern>confirmation</url-pattern>
         <url-pattern>delete-availability</url-pattern>
+        <url-pattern>delete-experience</url-pattern>
+        <url-pattern>delete-goal</url-pattern>
         <url-pattern>delete-tutor-session</url-pattern>
         <url-pattern>history</url-pattern>
+        <url-pattern>my-students</url-pattern>
         <url-pattern>rating</url-pattern>
         <url-pattern>registration</url-pattern>
         <url-pattern>scheduling</url-pattern>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,68 @@
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+         http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
+    <!-- <servlet>
+        <servlet-name>comingsoon</servlet-name>
+        <servlet-class>mysite.server.ComingSoonServlet</servlet-class>
+    </servlet> -->
+    <security-constraint>
+        <web-resource-collection>
+            <url-pattern>/history.html</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>*</role-name>
+        </auth-constraint>
+    </security-constraint>
+    <security-constraint>
+        <web-resource-collection>
+            <url-pattern>/confirmation.html</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>*</role-name>
+        </auth-constraint>
+    </security-constraint>
+    <security-constraint>
+        <web-resource-collection>
+            <url-pattern>/manage-availability.html</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>*</role-name>
+        </auth-constraint>
+    </security-constraint>
+    <security-constraint>
+        <web-resource-collection>
+            <url-pattern>/manage-sessions.html</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>*</role-name>
+        </auth-constraint>
+    </security-constraint>
+    <security-constraint>
+        <web-resource-collection>
+            <url-pattern>/registration.html</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>*</role-name>
+        </auth-constraint>
+    </security-constraint>
+    <security-constraint>
+        <web-resource-collection>
+            <url-pattern>/scheduling.html</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>*</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <!-- <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>admin</web-resource-name>
+            <url-pattern>/admin/*</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>admin</role-name>
+        </auth-constraint>
+    </security-constraint> -->
+</web-app>

--- a/src/main/webapp/confirmation.js
+++ b/src/main/webapp/confirmation.js
@@ -12,12 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/** Gets a list of the user's scheduled sessions from the server and displays them on the page. */
 function getScheduledSessions() {
-    var queryString = new Array();
-    window.onload = readTutorID(queryString, window);
-    const studentID = queryString["studentID"];
+    return getScheduledSessionsHelper(window);
+}
 
-    fetch('/confirmation?studentID=' + studentID, {method: 'GET'}).then(response => response.json()).then((scheduledSessions) => {
+//Helper function for getScheduledSessions, used for testing
+async function getScheduledSessionsHelper(window) {
+    await fetch('/confirmation', {method: 'GET'}).then((response) => {
+        //if the student id is not the id of the current user
+        if(response.redirected) {
+            window.location.href = response.url
+            return [];
+        }
+        return response.json();
+        
+    }).then((scheduledSessions) => {
         if(scheduledSessions.error) {
             var message = document.createElement("p");
             p.innerText = scheduledSessions.error;
@@ -25,28 +35,13 @@ function getScheduledSessions() {
             return;
         }
         scheduledSessions.forEach((scheduledSession) => {
-            document.getElementById('scheduledSessions').appendChild(createScheduledSessionBox(scheduledSession, studentID));
+            document.getElementById('scheduledSessions').appendChild(createScheduledSessionBox(scheduledSession));
         })
     });
 }
 
-// Referenced to https://www.aspsnippets.com/Articles/Redirect-to-another-Page-on-Button-Click-using-JavaScript.aspx#:~:text=Redirecting%
-// 20on%20Button%20Click%20using%20JavaScript&text=Inside%20the%20Send%20JavaScript%20function,is%20redirected%20to%20the%20URL on June 23rd.
-// This function reads the id of the tutor that the student has selected, which is passed as an URI component, and add it to the queryString array..
-function readTutorID(queryString, window) {
-    if (queryString.length == 0) {
-        if (window.location.search.split('?').length > 1) {
-            var params = window.location.search.split('?')[1].split('&');
-            for (var i = 0; i < params.length; i++) {
-                var key = params[i].split('=')[0];
-                var value = decodeURIComponent(params[i].split('=')[1]);
-                queryString[key] = value;
-            }
-        }
-    }
-}
 
-function createScheduledSessionBox(scheduledSession, studentID) {
+function createScheduledSessionBox(scheduledSession) {
 
     var months = [ "January", "February", "March", "April", "May", "June", 
            "July", "August", "September", "October", "November", "December" ];

--- a/src/main/webapp/confirmation.js
+++ b/src/main/webapp/confirmation.js
@@ -88,8 +88,7 @@ function createScheduledSessionBox(scheduledSession) {
 //Helper function for testing purposes
 //Sets the tutor element's email field to the tutor email
 function setTutorEmail(tutorElement, tutorID) {
-    var tutor;
-    return getUser(tutorID).then(user => tutor = user).then(() => {
+    return getUser(tutorID).then(tutor => {
         tutorElement.innerHTML = "Tutoring Session with " + tutor.email;
     });
 }

--- a/src/main/webapp/history.js
+++ b/src/main/webapp/history.js
@@ -12,14 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/** Gets a list of the student's tutoring session history and displays them on the page. */
 function getTutoringSessionHistory() {
-    var queryString = new Array();
-    window.onload = readStudentID(queryString, window);
-    const studentID = queryString["userID"];
+    return getTutoringSessionHistoryHelper(window);
+}
 
-    const params = new URLSearchParams();
-    params.append('studentID', studentID);
-    fetch('/history?studentID=' + studentID, {method: 'GET'}).then(response => response.json()).then((tutoringSessions) => {
+//Helper function for getTutoringSessionHistory, used for testing.
+function getTutoringSessionHistoryHelper(window) {
+    fetch('/history', {method: 'GET'}).then((response) => {
+        //if the student id is not the id of the current user
+        if(response.redirected) {
+            window.location.href = response.url
+            return;
+        }
+        return response.json();
+    }).then((tutoringSessions) => {
         //if there was an error
         if(tutoringSessions.error) {
             var container = document.getElementById('tutoringSessionHistory');
@@ -33,22 +40,6 @@ function getTutoringSessionHistory() {
             document.getElementById('tutoringSessionHistory').appendChild(createTutoringSessionBox(tutoringSession));
         })
     });
-}
-
-// Referenced to https://www.aspsnippets.com/Articles/Redirect-to-another-Page-on-Button-Click-using-JavaScript.aspx#:~:text=Redirecting%
-// 20on%20Button%20Click%20using%20JavaScript&text=Inside%20the%20Send%20JavaScript%20function,is%20redirected%20to%20the%20URL on June 23rd.
-// This function reads the id of the tutor that the student has selected, which is passed as an URI component, and add it to the queryString array..
-function readStudentID(queryString, window) {
-    if (queryString.length == 0) {
-        if (window.location.search.split('?').length > 1) {
-            var params = window.location.search.split('?')[1].split('&');
-            for (var i = 0; i < params.length; i++) {
-                var key = params[i].split('=')[0];
-                var value = decodeURIComponent(params[i].split('=')[1]);
-                queryString[key] = value;
-            }
-        }
-    }
 }
 
 function createTutoringSessionBox(tutoringSession) {
@@ -148,8 +139,6 @@ function loadStars(starsElement, tutoringSession) {
 
 function rateTutor(tutoringSession, rating) {
     const params = new URLSearchParams();
-    params.append('studentID', tutoringSession.studentID);
-    params.append('tutorID', tutoringSession.tutorID);
     params.append('sessionId', tutoringSession.id);
     params.append('rating', rating);
     fetch('/rating', {method: 'POST', body: params});

--- a/src/main/webapp/manage-sessions.html
+++ b/src/main/webapp/manage-sessions.html
@@ -45,5 +45,6 @@
         <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
         <script src="manage-sessions.js"></script>
         <script src="registration.js"></script>
+        <script src="profile.js"></script>
     </body>
 </html>

--- a/src/main/webapp/manage-sessions.js
+++ b/src/main/webapp/manage-sessions.js
@@ -12,12 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/** Gets a list of scheduled sessions for the student and displays them on the page with a delete button. */
 function getTutorSessionsManage() {
-    var queryString = new Array();
-    window.onload = readTutorID(queryString, window);
-    const userID = queryString["userID"];
+    return getTutorSessionsManageHelper(window);
+}
 
-    fetch('/confirmation?studentID=' + userID, {method: 'GET'}).then(response => response.json()).then((scheduledSessions) => {
+//Helper function for getTutorSessionManage, used for testing
+async function getTutorSessionsManageHelper(window) {
+    await fetch('/confirmation', {method: 'GET'}).then((response) => {
+        //if the student id is not the id of the current user
+        if(response.redirected) {
+            window.location.href = response.url
+            return [];
+        }
+        return response.json();
+    }).then((scheduledSessions) => {
         if(scheduledSessions.error) {
             var message = document.createElement("p");
             p.innerText = scheduledSessions.error;
@@ -25,28 +34,12 @@ function getTutorSessionsManage() {
             return;
         }
         scheduledSessions.forEach((scheduledSession) => {
-            document.getElementById('scheduledSessions').appendChild(createScheduledSessionBoxManage(scheduledSession, userID));
-        })
+            document.getElementById('scheduledSessions').appendChild(createScheduledSessionBoxManage(scheduledSession));
+        });
     });
 }
 
-// Referenced to https://www.aspsnippets.com/Articles/Redirect-to-another-Page-on-Button-Click-using-JavaScript.aspx#:~:text=Redirecting%
-// 20on%20Button%20Click%20using%20JavaScript&text=Inside%20the%20Send%20JavaScript%20function,is%20redirected%20to%20the%20URL on June 23rd.
-// This function reads the id of the tutor that the student has selected, which is passed as an URI component, and add it to the queryString array..
-function readTutorID(queryString, window) {
-    if (queryString.length == 0) {
-        if (window.location.search.split('?').length > 1) {
-            var params = window.location.search.split('?')[1].split('&');
-            for (var i = 0; i < params.length; i++) {
-                var key = params[i].split('=')[0];
-                var value = decodeURIComponent(params[i].split('=')[1]);
-                queryString[key] = value;
-            }
-        }
-    }
-}
-
-function createScheduledSessionBoxManage(scheduledSession, userID) {
+function createScheduledSessionBoxManage(scheduledSession) {
     var months = [ "January", "February", "March", "April", "May", "June", 
            "July", "August", "September", "October", "November", "December" ];
 
@@ -115,19 +108,15 @@ function setTutorEmail(tutorElement, tutorID) {
 }
 
 
-function cancelTutorSession(userID, window, scheduledSession) {
+function cancelTutorSession(window, scheduledSession) {
     const params = new URLSearchParams();
-    params.append('tutorID', scheduledSession.tutorID);
-    params.append('studentID', scheduledSession.studentID);
-    params.append('year', scheduledSession.timeslot.date.year);
-    params.append('month', scheduledSession.timeslot.date.month);
-    params.append('day', scheduledSession.timeslot.date.dayOfMonth);
-    params.append('start', scheduledSession.timeslot.start);
-    params.append('end', scheduledSession.timeslot.end);
-    params.append('subtopics', scheduledSession.subtopics);
-    params.append('questions', scheduledSession.questions);
-    params.append('rating', scheduledSession.rating);
     params.append('id', scheduledSession.id);
 
-    fetch('/delete-tutor-session', {method: 'POST', body: params});
+    fetch('/delete-tutor-session', {method: 'POST', body: params}).then((response) => {
+        //if the student id is not the id of the current user
+        if(response.redirected) {
+            window.location.href = response.url
+            return;
+        }
+    });
 }

--- a/src/main/webapp/manage-sessions.js
+++ b/src/main/webapp/manage-sessions.js
@@ -82,7 +82,7 @@ function createScheduledSessionBoxManage(scheduledSession) {
     cancelButtonElement.style.display = 'inline';
     cancelButtonElement.className = 'btn btn-default btn-lg';
     cancelButtonElement.addEventListener('click', () => {
-        cancelTutorSession(userID, window, scheduledSession);
+        cancelTutorSession(window, scheduledSession);
 
         scheduledSessionElement.remove();
     });

--- a/src/main/webapp/my-students.js
+++ b/src/main/webapp/my-students.js
@@ -13,7 +13,18 @@
 // limitations under the License.
 
 function getMyStudents() {
-    fetch('/my-students', {method: 'GET'}).then(response => response.json()).then((students) => {
+    return getMyStudentsHelper(window);
+}
+
+async function getMyStudentsHelper(window) {
+    await fetch('/my-students', {method: 'GET'}).then((response) => {
+        //if the tutor id is not the id of the current user
+        if(response.redirected) {
+            window.location.href = response.url
+            return [];
+        }
+        return response.json();
+    }).then((students) => {
         if(students.error) {
             var message = document.createElement("p");
             p.innerText = students.error;

--- a/src/main/webapp/my-students.js
+++ b/src/main/webapp/my-students.js
@@ -13,11 +13,7 @@
 // limitations under the License.
 
 function getMyStudents() {
-    var queryString = new Array();
-    window.onload = readTutorID(queryString, window);
-    const userID = queryString["userID"];
-
-    fetch('/my-students?tutorID=' + userID, {method: 'GET'}).then(response => response.json()).then((students) => {
+    fetch('/my-students', {method: 'GET'}).then(response => response.json()).then((students) => {
         if(students.error) {
             var message = document.createElement("p");
             p.innerText = students.error;
@@ -29,24 +25,10 @@ function getMyStudents() {
         })
     });
 }
-// Referenced to https://www.aspsnippets.com/Articles/Redirect-to-another-Page-on-Button-Click-using-JavaScript.aspx#:~:text=Redirecting%
-// 20on%20Button%20Click%20using%20JavaScript&text=Inside%20the%20Send%20JavaScript%20function,is%20redirected%20to%20the%20URL on June 23rd.
-// This function reads the id of the tutor that the student has selected, which is passed as an URI component, and add it to the queryString array..
-function readTutorID(queryString, window) {
-    if (queryString.length == 0) {
-        if (window.location.search.split('?').length > 1) {
-            var params = window.location.search.split('?')[1].split('&');
-            for (var i = 0; i < params.length; i++) {
-                var key = params[i].split('=')[0];
-                var value = decodeURIComponent(params[i].split('=')[1]);
-                queryString[key] = value;
-            }
-        }
-    }
-}
 
 /** Creates a div element containing information about a student. */
 function createStudentBox(student) {
+    console.log(student);
     const studentContainer = document.createElement("div");
     const name = document.createElement("h3");
     const email = document.createElement("h6");

--- a/src/main/webapp/progress.js
+++ b/src/main/webapp/progress.js
@@ -50,7 +50,7 @@ function getExperiences(document, loginStatus) {
     const params = new URLSearchParams();
     params.append('studentID', studentID);
     fetch('/experience?studentID=' + studentID, {method: 'GET'}).then(response => response.json()).then((experiences) => {
-        getExperiencesHelper(document, experiences);
+        getExperiencesHelper(document, experiences, loginStatus);
     });
 
     // If the user is a student, allow them to add experiences
@@ -61,7 +61,7 @@ function getExperiences(document, loginStatus) {
     }
 }
 
-function getExperiencesHelper(document, experiences) {
+function getExperiencesHelper(document, experiences, loginStatus) {
     //if there was an error
     if(experiences.error) {
         var experienceContainer = document.getElementById('experiences');
@@ -91,7 +91,7 @@ function getGoals(document, loginStatus) {
     const params = new URLSearchParams();
     params.append('studentID', studentID);
     fetch('/goal?studentID=' + studentID, {method: 'GET'}).then(response => response.json()).then((goals) => {
-        getGoalsHelper(document, goals);
+        getGoalsHelper(document, goals, loginStatus);
     });
 
     // If the user is a student, allow them to add goals
@@ -102,7 +102,7 @@ function getGoals(document, loginStatus) {
     }
 }
 
-function getGoalsHelper(document, goals) {
+function getGoalsHelper(document, goals, loginStatus) {
     //if there was an error
     if(goals.error) {
         var goalContainer = document.getElementById('goals');
@@ -319,48 +319,43 @@ function createExperienceBox(experience, loginStatus) {
 }
 
 function addGoal(window) {
+    const params = new URLSearchParams();
+
     var queryString = new Array();
     window.onload = readStudentID(queryString, window);
     const studentID = queryString["studentID"];
 
-    const params = new URLSearchParams();
-
     params.append('goal', document.getElementById('newGoal').value);
-    params.append('studentID', studentID);
 
     fetch('/goal', {method: 'POST', body: params}).then(() => {
         window.location.href = "/progress.html?studentID=" + studentID;
     });
 }
 
-function deleteGoal(goal, studentID, window) {
+function deleteGoal(goal, window) {
     const params = new URLSearchParams();
-
-    params.append('studentID', studentID);
     params.append('id', goal.id);
 
     fetch('/delete-goal', {method: 'POST', body: params});
 }
 
 function addExperience(window) {
+    const params = new URLSearchParams();
+
     var queryString = new Array();
     window.onload = readStudentID(queryString, window);
     const studentID = queryString["studentID"];
 
-    const params = new URLSearchParams();
-
     params.append('experience', document.getElementById('newExperience').value);
-    params.append('studentID', studentID);
 
     fetch('/experience', {method: 'POST', body: params}).then(() => {
         window.location.href = "/progress.html?studentID=" + studentID;
     });
 }
 
-function deleteExperience(experience, studentID, window) {
+function deleteExperience(experience, window) {
     const params = new URLSearchParams();
 
-    params.append('studentID', studentID);
     params.append('id', experience.id);
 
     fetch('/delete-experience', {method: 'POST', body: params});

--- a/src/main/webapp/registration.js
+++ b/src/main/webapp/registration.js
@@ -69,6 +69,9 @@ function displayLoginLogoutLinkHelper(document, loginStatus) {
         document.getElementById('history').style.display = "block";
         document.getElementById('logout').style.display = "block";
         document.getElementById('logout-url').href = loginStatus.url;
+        document.getElementById('logout-url').addEventListener('click', () => {
+             fetch('/logout', {method: 'POST'});
+        });
         document.getElementById('profile').addEventListener('click', () => {
             setProfileQueryString(window, loginStatus);
         });

--- a/src/main/webapp/scheduling.js
+++ b/src/main/webapp/scheduling.js
@@ -13,48 +13,50 @@
 // limitations under the License.
 
 function scheduleTutorSession() {
-    scheduleTutorSessionHelper(window);
+    return scheduleTutorSessionHelper(window);
 }
 
-function scheduleTutorSessionHelper(window) {
-    getUserId().then(function(studentID) {
-        var queryString = new Array();
-        window.onload = readComponents(queryString, window);
-        const tutorID = queryString["tutorID"];
-        const start = queryString["start"];
-        const end = queryString["end"];
-        const year = queryString["year"];
-        const month = queryString["month"];
-        const day = queryString["day"];
+async function scheduleTutorSessionHelper(window) {
+    var queryString = new Array();
+    window.onload = readComponents(queryString, window);
+    const tutorID = queryString["tutorID"];
+    const start = queryString["start"];
+    const end = queryString["end"];
+    const year = queryString["year"];
+    const month = queryString["month"];
+    const day = queryString["day"];
 
-        var subtopics = document.getElementById("topics").value;
-        var questions = document.getElementById("questions").value;
+    var subtopics = document.getElementById("topics").value;
+    var questions = document.getElementById("questions").value;
 
-        const params = new URLSearchParams();
-        params.append('tutorID', tutorID);
-        params.append('start', start);
-        params.append('end', end);
-        params.append('year', year);
-        params.append('month', month);
-        params.append('day', day);
-        params.append('studentID', studentID);
-        params.append('subtopics', subtopics);
-        params.append('questions', questions);
+    const params = new URLSearchParams();
+    params.append('tutorID', tutorID);
+    params.append('start', start);
+    params.append('end', end);
+    params.append('year', year);
+    params.append('month', month);
+    params.append('day', day);
+    params.append('subtopics', subtopics);
+    params.append('questions', questions);
 
-        // Redirect user to confirmation
-        fetch('/scheduling', {method: 'POST', body: params}).then(response => response.json()).then((tutors) => {
-            if(tutors.error) {
-                var message = document.createElement("p");
-                message.innerText = tutors.error;
-                document.body.appendChild(message);
-                return;
-            }
+    // Redirect user to confirmation
+    await fetch('/scheduling', {method: 'POST', body: params}).then((response) => {
+        //if the student id is not the id of the current user
+        if(response.redirected) {
+            window.location.href = response.url
+            return [];
+        }
+        return response.json();
+    }).then((tutors) => {
+        if(tutors.error) {
+            var message = document.createElement("p");
+            message.innerText = tutors.error;
+            document.body.appendChild(message);
+            return;
+        }
 
-            redirectToConfirmation(studentID, window);
-        });
-
+        redirectToConfirmation(window);
     });
-
 }
 
 // Referenced to https://www.aspsnippets.com/Articles/Redirect-to-another-Page-on-Button-Click-using-JavaScript.aspx#:~:text=Redirecting%
@@ -75,7 +77,7 @@ function readComponents(queryString, window) {
 }
 
 // Redirects the user to the confirmation page and passes down the student ID.
-function redirectToConfirmation(studentID, window) {
-    var url = "confirmation.html?studentID=" + encodeURIComponent(studentID);
+function redirectToConfirmation(window) {
+    var url = "confirmation.html";
     window.location.href = url;
 }

--- a/src/main/webapp/webapptests/spec/SpecConfirmation.js
+++ b/src/main/webapp/webapptests/spec/SpecConfirmation.js
@@ -13,35 +13,30 @@
 // limitations under the License.
 
 describe("Confirmation", function() {
-    describe("when the list of upcoming sessions is loaded", function() {
-        var mockWindow = {location: {href: "confirmation.html?studentID=123", search: "?studentID=123"}};
 
+    describe("when the list of upcoming sessions is loaded", function() {
         it("should trigger the fetch function", function() {
-            spyOn(window, "onload").and.callFake(function() {
-                readTutorID(queryString, window);
-            });
-            spyOn(window, 'fetch').and.callThrough();
-            getScheduledSessions(mockWindow);
-            expect(window.fetch).toHaveBeenCalledWith('/confirmation?studentID=undefined', {method: 'GET'});
+            spyOn(window, 'fetch').and.returnValue(Promise.resolve({json: () => Promise.resolve([])}));
+            getScheduledSessions();
+            expect(window.fetch).toHaveBeenCalledWith('/confirmation', {method: 'GET'});
             expect(window.fetch).toHaveBeenCalled();
         });
     });
 
-    describe("when the tutor ID is read", function() {
-        var mockWindow = {location: {href: "confirmation.html?studentID=123", search: "?studentID=123"}};
-        var queryString = new Array();
-        readTutorID(queryString, mockWindow);
-
-        it("should set tutorID inside queryString as the tutorID", function() {
-            expect(queryString["studentID"]).toEqual("123");
+    describe("when user tries to access someone else's confirmation page", function() {
+        var mockWindow = {location: {href: "confirmation.html"}};
+        var response = {redirected: true, url: "/homepage.html"};
+        it("should redirect user to homepage", async function() {
+            spyOn(window, 'fetch').and.returnValue(Promise.resolve(response));
+            await getScheduledSessionsHelper(mockWindow);
+            expect(mockWindow.location.href).toBe('/homepage.html');
         });
     });
 
     describe("when a scheduled session box is created", function() {
         var scheduledSession = {tutorID: "123", timeslot: {start: 480, date: {month: 4, dayOfMonth: 18, year: 2020}}};
-        var studentID = "123";
 
-        var actual = createScheduledSessionBox(scheduledSession, studentID);
+        var actual = createScheduledSessionBox(scheduledSession);
 
         it("should return a list item element", function() {
             expect(actual.tagName).toEqual("LI");
@@ -62,7 +57,7 @@ describe("Confirmation", function() {
 
         it("should have the inner HTML of the h3 tag equal to to the email of the tutor", function() {
             var tutor = {email: "tester@gmail.com"};
-            spyOn(window, "fetch").and.returnValues(Promise.resolve({json: () => Promise.resolve(user)}), Promise.resolve({json: () => Promise.resolve(tutor)}));
+            spyOn(window, "fetch").and.returnValue(Promise.resolve({json: () => Promise.resolve(tutor)}));
 
             const tutorElement = document.createElement('h3');
             setTutorEmail(tutorElement, "123").then(() => {

--- a/src/main/webapp/webapptests/spec/SpecHistory.js
+++ b/src/main/webapp/webapptests/spec/SpecHistory.js
@@ -14,26 +14,21 @@
 
 describe("History", function() {
     describe("when the history of tutoring sessions is loaded", function() {
-        var mockWindow = {location: {href: "history.html?studentID=123", search: "?studentID=123"}};
-
         it("should trigger the fetch function", function() {
-            spyOn(window, "onload").and.callFake(function() {
-                readStudentID(queryString, window);
-            });
-            spyOn(window, 'fetch').and.callThrough();
-            getTutoringSessionHistory(mockWindow);
-            expect(window.fetch).toHaveBeenCalledWith('/history?studentID=undefined', {method: 'GET'});
+            spyOn(window, 'fetch').and.returnValue(Promise.resolve({json: () => Promise.resolve([])}));
+            getTutoringSessionHistory();
+            expect(window.fetch).toHaveBeenCalledWith('/history', {method: 'GET'});
             expect(window.fetch).toHaveBeenCalled();
         });
     });
 
-    describe("when the student ID is read", function() {
-        var mockWindow = {location: {href: "history.html?studentID=123", search: "?studentID=123"}};
-        var queryString = new Array();
-        readStudentID(queryString, mockWindow);
-
-        it("should set studentID inside queryString as the studentID passed down", function() {
-            expect(queryString["studentID"]).toEqual("123");
+    describe("when user tries to access someone else's confirmation page", function() {
+        var mockWindow = {location: {href: "history.html"}};
+        var response = {redirected: true, url: "/homepage.html"};
+        it("should redirect user to homepage", async function() {
+            spyOn(window, 'fetch').and.returnValue(Promise.resolve(response));
+            await getTutoringSessionHistoryHelper(mockWindow);
+            expect(mockWindow.location.href).toBe('/homepage.html');
         });
     });
 
@@ -132,11 +127,11 @@ describe("History", function() {
     });
 
     describe("when rateTutor is called", function() {
-        var fakeTutoringSession = {tutorID: "123", studentID: "123"};
+        var fakeTutoringSession = {id: "1"};
         var fakeRating = 5;
 
         it("should trigger the fetch function", function() {
-            spyOn(window, 'fetch').and.callThrough();
+            spyOn(window, 'fetch').and.returnValue(Promise.resolve({json: () => Promise.resolve([])}));
             rateTutor(fakeTutoringSession, fakeRating);
             expect(window.fetch).toHaveBeenCalled();
         });

--- a/src/main/webapp/webapptests/spec/SpecManageAvailability.js
+++ b/src/main/webapp/webapptests/spec/SpecManageAvailability.js
@@ -15,33 +15,18 @@
 describe("Manage Availability", function() {
 
     describe("when the tutor requests to see a their availability", function() {
-        var mockWindow = {location: {href: "manage-availability.html?tutorID=test%40gmail.com", search: "?tutorID=test%40gmail.com"}};
+        var mockWindow = {location: {href: "manage-availability.html"}};
 
         it("should trigger the fetch function", function() {
-            spyOn(window, "onload").and.callFake(function() {
-                readTutorID(queryString, window);
-            });
-            spyOn(document, 'getElementById').and.returnValue("test@gmail.com");
-            spyOn(window, 'fetch').and.callThrough();
+            spyOn(window, 'fetch').and.returnValue(Promise.resolve({json: () => Promise.resolve([])}));
             getAvailabilityManage(mockWindow);
             expect(window.fetch).toHaveBeenCalled();
         });
     });
-
-    describe("when the tutor ID is read", function() {
-        var mockWindow = {location: {href: "manage-availability.html?tutorID=test%40gmail.com", search: "?tutorID=test%40gmail.com"}};
-        var queryString = new Array();
-        readTutorID(queryString, mockWindow);
-
-        it("should set tutorID inside queryString as the tutorID", function() {
-            expect(queryString["tutorID"]).toEqual("test@gmail.com");
-        });
-    });
-
+    
     describe("when a time slot box is created", function() {
         var timeslot = {start: 480, date: {month: 4, dayOfMonth: 18, year: 2020}};
-        var tutorID = "test@gmail.com";
-        var actual = createTimeSlotBoxManage(timeslot, tutorID);
+        var actual = createTimeSlotBoxManage(timeslot);
 
         it("should return a list item element", function() {
             expect(actual.tagName).toEqual("LI");
@@ -69,11 +54,47 @@ describe("Manage Availability", function() {
         });
     });
 
+    describe("when a user adds a time slot", function() {
+        mockWindow = {location: {href: "manage-availability.html"}}
+        var startHour = document.createElement("select");
+        var startMinute = document.createElement("select");
+        var endHour = document.createElement("select");
+        var endMinute = document.createElement("select");
+        var day = document.createElement("select");
+        var month = document.createElement("select");
+        var year = document.createElement("select");
+        startHour.value = 1;
+        startMinute.value = 30;
+        endHour.value = 3;
+        endMinute.value = 30;
+        day.value = 1;
+        month.value = 1;
+        year.value = 2020;
+
+        var params = new URLSearchParams();
+        params.append('startHour', 1);
+        params.append('startMinute', 30);
+        params.append('endHour', 3);
+        params.append('endMinute', 30);
+        params.append('day', 1);
+        params.append('month', 1);
+        params.append('year', 2020);
+
+        it("should trigger the fetch function", function() {
+            spyOn(document, "getElementById").and.returnValues(startHour, startMinute, endHour, endMinute, day, month, year);
+
+            spyOn(window, 'fetch').and.returnValue(Promise.resolve({json: () => Promise.resolve([])}));
+            addTimeSlotHelper(mockWindow);
+            expect(window.fetch).toHaveBeenCalledWith('/add-availability', {method: 'POST', body: params})
+            expect(window.fetch).toHaveBeenCalled();
+            expect(mockWindow.location.href).toBe("manage-availability.html");
+        });
+    });
+
     describe("when a user deletes a time slot", function() {
         var mockWindow = {location: {href: "manage-availability.html"}};
         var timeslot = {duration: 60, end: 540, start: 480, date: {year: 2020, month: 5, dayOfMonth: 18}};
         var params = new URLSearchParams();
-        params.append('tutorID', "test@gmail.com");
         params.append('year', 2020);
         params.append('month', 5);
         params.append('day', 18);
@@ -81,8 +102,8 @@ describe("Manage Availability", function() {
         params.append('end', 540);
 
         it("should trigger the fetch function", function() {
-            spyOn(window, 'fetch').and.callThrough();
-            deleteTimeSlot("test@gmail.com", mockWindow, timeslot);
+            spyOn(window, 'fetch').and.returnValue(Promise.resolve({json: () => Promise.resolve([])}));
+            deleteTimeSlot(mockWindow, timeslot);
             expect(window.fetch).toHaveBeenCalledWith('/delete-availability', {method: 'POST', body: params})
             expect(window.fetch).toHaveBeenCalled();
         });

--- a/src/main/webapp/webapptests/spec/SpecManageAvailability.js
+++ b/src/main/webapp/webapptests/spec/SpecManageAvailability.js
@@ -15,12 +15,23 @@
 describe("Manage Availability", function() {
 
     describe("when the tutor requests to see a their availability", function() {
-        var mockWindow = {location: {href: "manage-availability.html"}};
+        var mockWindow = {location: {href: "manage-availability.html?tutorID=123", search: "?123"}};
 
-        it("should trigger the fetch function", function() {
+        it("should trigger the fetch function", async function() {
             spyOn(window, 'fetch').and.returnValue(Promise.resolve({json: () => Promise.resolve([])}));
-            getAvailabilityManage(mockWindow);
+            getAvailabilityManageHelper(mockWindow);
             expect(window.fetch).toHaveBeenCalled();
+        });
+    });
+
+    describe("when user tries to access someone else's manage availability page", function() {
+        var loginStatus = {userId: "000"};
+        var mockWindow = {location: {href: "manage-availability.html?tutorID=123", search: "?123"}};
+        var response = {redirected: true, url: "/homepage.html"};
+        it("should redirect user to homepage", async function() {
+            spyOn(window, 'fetch').and.returnValue(Promise.resolve({json: () => Promise.resolve(loginStatus)}));
+            await getAvailabilityManageHelper(mockWindow);
+            expect(mockWindow.location.href).toBe('/homepage.html');
         });
     });
     
@@ -81,13 +92,14 @@ describe("Manage Availability", function() {
         params.append('year', 2020);
 
         it("should trigger the fetch function", function() {
+            var mockWindow = {location: {href: "manage-availability.html?tutorID=123", search: "?123"}};
             spyOn(document, "getElementById").and.returnValues(startHour, startMinute, endHour, endMinute, day, month, year);
 
             spyOn(window, 'fetch').and.returnValue(Promise.resolve({json: () => Promise.resolve([])}));
             addTimeSlotHelper(mockWindow);
             expect(window.fetch).toHaveBeenCalledWith('/add-availability', {method: 'POST', body: params})
             expect(window.fetch).toHaveBeenCalled();
-            expect(mockWindow.location.href).toBe("manage-availability.html");
+            expect(mockWindow.location.href).toBe("manage-availability.html?tutorID=123");
         });
     });
 

--- a/src/main/webapp/webapptests/spec/SpecManageSessions.js
+++ b/src/main/webapp/webapptests/spec/SpecManageSessions.js
@@ -15,26 +15,21 @@
 describe("Manage Sessions", function() {
 
     describe("when the student requests to see a their scheduled sessions", function() {
-        var mockWindow = {location: {href: "manage-sessions.html?studentID=123", search: "?studentID=123"}};
-
         it("should trigger the fetch function", function() {
-            spyOn(window, "onload").and.callFake(function() {
-                readTutorID(queryString, window);
-            });
-            spyOn(window, 'fetch').and.callThrough();
-            getTutorSessionsManage(mockWindow);
-            expect(window.fetch).toHaveBeenCalledWith('/confirmation?studentID=undefined', {method: 'GET'});
+            spyOn(window, 'fetch').and.returnValue(Promise.resolve({json: () => Promise.resolve([])}));
+            getTutorSessionsManage();
+            expect(window.fetch).toHaveBeenCalledWith('/confirmation', {method: 'GET'});
             expect(window.fetch).toHaveBeenCalled();
         });
     });
 
-    describe("when the student id is read", function() {
-        var mockWindow = {location: {href: "manage-sessions.html?studentID=123", search: "?studentID=123"}};
-        var queryString = new Array();
-        readTutorID(queryString, mockWindow);
-
-        it("should set studentID inside queryString as the studentID", function() {
-            expect(queryString["studentID"]).toEqual("123");
+    describe("when user tries to access someone else's sessions page", function() {
+        var mockWindow = {location: {href: "manage-sessions.html"}};
+        var response = {redirected: true, url: "/homepage.html"};
+        it("should redirect user to homepage", async function() {
+            spyOn(window, 'fetch').and.returnValue(Promise.resolve(response));
+            await getTutorSessionsManageHelper(mockWindow);
+            expect(mockWindow.location.href).toBe('/homepage.html');
         });
     });
 
@@ -85,26 +80,16 @@ describe("Manage Sessions", function() {
     });
 
     describe("when a user cancels a tutoring session", function() {
-        var mockWindow = {location: {href: "manage-sessions.html?studentID=123", search: "?studentID=123"}};
+        var mockWindow = {location: {href: "manage-sessions.html"}};
         var scheduledSession = {tutorID: "123", studentID: "123", 
                                 subtopics: null, questions: null, rating: 5, id: 1,
                                 timeslot: {start: 600, end: 660,  date: {month: 4, dayOfMonth: 18, year: 2020}}};
         var params = new URLSearchParams();
-        params.append('tutorID', "123");
-        params.append('studentID', "123");
-        params.append('year', 2020);
-        params.append('month', 4);
-        params.append('day', 18);
-        params.append('start', 600);
-        params.append('end', 660);
-        params.append('subtopics', null);
-        params.append('questions', null);
-        params.append('rating', 5);
         params.append('id', 1);
 
         it("should trigger the fetch function", function() {
             spyOn(window, 'fetch').and.callThrough();
-            cancelTutorSession("test@gmail.com", mockWindow, scheduledSession);
+            cancelTutorSession(mockWindow, scheduledSession);
             expect(window.fetch).toHaveBeenCalledWith('/delete-tutor-session', {method: 'POST', body: params})
             expect(window.fetch).toHaveBeenCalled();
         });

--- a/src/main/webapp/webapptests/spec/SpecMyStudents.js
+++ b/src/main/webapp/webapptests/spec/SpecMyStudents.js
@@ -15,7 +15,7 @@
 describe("My Students", function() {
 
     describe("when the tutor requests to see their student", function() {
-        var mockWindow = {location: {href: "my-students.html?userID=123", search: "?userID=123"}};
+        var mockWindow = {location: {href: "my-students.html"}};
 
         it("should trigger the fetch function", function() {
             spyOn(window, "onload").and.callFake(function() {
@@ -23,18 +23,8 @@ describe("My Students", function() {
             });
             spyOn(window, 'fetch').and.callThrough();
             getMyStudents(mockWindow);
-            expect(window.fetch).toHaveBeenCalledWith('/my-students?tutorID=undefined', {method: 'GET'});
+            expect(window.fetch).toHaveBeenCalledWith('/my-students', {method: 'GET'});
             expect(window.fetch).toHaveBeenCalled();
-        });
-    });
-
-    describe("when the tutor ID is read", function() {
-        var mockWindow = {location: {href: "my-students.html?userID=123", search: "?userID=123"}};
-        var queryString = new Array();
-        readTutorID(queryString, mockWindow);
-
-        it("should set tutorID inside queryString as the tutorID", function() {
-            expect(queryString["userID"]).toEqual("123");
         });
     });
 

--- a/src/main/webapp/webapptests/spec/SpecMyStudents.js
+++ b/src/main/webapp/webapptests/spec/SpecMyStudents.js
@@ -18,13 +18,20 @@ describe("My Students", function() {
         var mockWindow = {location: {href: "my-students.html"}};
 
         it("should trigger the fetch function", function() {
-            spyOn(window, "onload").and.callFake(function() {
-                readTutorID(queryString, window);
-            });
-            spyOn(window, 'fetch').and.callThrough();
-            getMyStudents(mockWindow);
+            spyOn(window, 'fetch').and.returnValue(Promise.resolve({json: () => Promise.resolve([])}));
+            getMyStudents();
             expect(window.fetch).toHaveBeenCalledWith('/my-students', {method: 'GET'});
             expect(window.fetch).toHaveBeenCalled();
+        });
+    });
+
+    describe("when user tries to access someone else's students page", function() {
+        var mockWindow = {location: {href: "my-students.html"}};
+        var response = {redirected: true, url: "/homepage.html"};
+        it("should redirect user to homepage", async function() {
+            spyOn(window, 'fetch').and.returnValue(Promise.resolve(response));
+            await getMyStudentsHelper(mockWindow);
+            expect(mockWindow.location.href).toBe('/homepage.html');
         });
     });
 

--- a/src/main/webapp/webapptests/spec/SpecProgress.js
+++ b/src/main/webapp/webapptests/spec/SpecProgress.js
@@ -70,7 +70,7 @@ describe("Progress", function() {
             });
             spyOn(window, 'fetch').and.returnValue(Promise.resolve({json: () => Promise.resolve()}));
             getExperiences(document, mockLoginStatus, mockWindow);
-            expect(window.fetch).toHaveBeenCalledWith('/add-experience?studentID=undefined', {method: 'GET'});
+            expect(window.fetch).toHaveBeenCalledWith('/experience?studentID=undefined', {method: 'GET'});
             expect(document.getElementById('experiences-form').style.display).toBe('block');
         });
 
@@ -83,7 +83,7 @@ describe("Progress", function() {
             });
             spyOn(window, 'fetch').and.returnValue(Promise.resolve({json: () => Promise.resolve()}));
             getExperiences(document, mockLoginStatus, mockWindow);
-            expect(window.fetch).toHaveBeenCalledWith('/add-experience?studentID=undefined', {method: 'GET'});
+            expect(window.fetch).toHaveBeenCalledWith('/experience?studentID=undefined', {method: 'GET'});
             expect(document.getElementById('experiences-form').style.display).toBe('none');
         });
     });
@@ -140,7 +140,7 @@ describe("Progress", function() {
             });
             spyOn(window, 'fetch').and.returnValue(Promise.resolve({json: () => Promise.resolve()}));
             getGoals(document, mockLoginStatus, mockWindow);
-            expect(window.fetch).toHaveBeenCalledWith('/add-goal?studentID=undefined', {method: 'GET'});
+            expect(window.fetch).toHaveBeenCalledWith('/goal?studentID=undefined', {method: 'GET'});
             expect(document.getElementById('goals-form').style.display).toBe('block');
         });
 
@@ -153,7 +153,7 @@ describe("Progress", function() {
             });
             spyOn(window, 'fetch').and.returnValue(Promise.resolve({json: () => Promise.resolve()}));
             getGoals(document, mockLoginStatus, mockWindow);
-            expect(window.fetch).toHaveBeenCalledWith('/add-goal?studentID=undefined', {method: 'GET'});
+            expect(window.fetch).toHaveBeenCalledWith('/goal?studentID=undefined', {method: 'GET'});
             expect(document.getElementById('goals-form').style.display).toBe('none');
         });
     });
@@ -407,15 +407,11 @@ describe("Progress", function() {
         it("should trigger the fetch function with the correct params", function() {
             var params = new URLSearchParams();
             params.append('goal', "undefined");
-            params.append('studentID', 123);
-
-            spyOn(window, "onload").and.callFake(function() {
-                readStudentID(queryString, window);
-            });
+        
             spyOn(window, 'fetch').and.callThrough();
             spyOn(document, 'getElementById').and.returnValue("test");
             addGoal(mockWindow);
-            expect(window.fetch).toHaveBeenCalledWith('/add-goal', {method: 'POST', body: params});
+            expect(window.fetch).toHaveBeenCalledWith('/goal', {method: 'POST', body: params});
         });
     });
 
@@ -433,7 +429,7 @@ describe("Progress", function() {
             spyOn(window, 'fetch').and.callThrough();
             spyOn(document, 'getElementById').and.returnValue("test");
             addExperience(mockWindow);
-            expect(window.fetch).toHaveBeenCalledWith('/add-experience', {method: 'POST', body: params});
+            expect(window.fetch).toHaveBeenCalledWith('/experience', {method: 'POST', body: params});
         });
     });
 
@@ -444,7 +440,6 @@ describe("Progress", function() {
 
         it("should trigger the fetch function with the correct params", function() {
             var params = new URLSearchParams();
-            params.append('studentID', 123);
             params.append('id', 1);
 
             spyOn(window, 'fetch').and.callThrough();
@@ -460,7 +455,6 @@ describe("Progress", function() {
 
         it("should trigger the fetch function with the correct params", function() {
             var params = new URLSearchParams();
-            params.append('studentID', 123);
             params.append('id', 1);
 
             spyOn(window, 'fetch').and.callThrough();

--- a/src/main/webapp/webapptests/spec/SpecScheduling.js
+++ b/src/main/webapp/webapptests/spec/SpecScheduling.js
@@ -14,25 +14,25 @@
 
 describe("Scheduling", function() {
     describe("when tutoring session is scheduled", function() {
-        var mockWindow = {location: {href: "scheduling.html?tutorID=elian%40google.com&start=480&end=540&year=2020&month=5&day=18", search: "?tutorID=elian%40google.com&start=480&end=540&year=2020&month=5&day=18"}};
+        var mockWindow = {location: {href: "scheduling.html?tutorID=123&start=480&end=540&year=2020&month=5&day=18", search: "?tutorID=123&start=480&end=540&year=2020&month=5&day=18"}};
 
-        it("should trigger the fetch function", function() {
+        it("should trigger the fetch function", async function() {
             spyOn(document, "getElementById").and.returnValue("");
-            spyOn(window, 'fetch').and.callThrough();
+            spyOn(window, 'fetch').and.returnValue(Promise.resolve({json: () => Promise.resolve([])}));
 
-            scheduleTutorSessionHelper(mockWindow);
+            await scheduleTutorSessionHelper(mockWindow);
 
             expect(window.fetch).toHaveBeenCalled();
         });
     });
 
     describe("when the URI components are read", function() {
-        var mockWindow = {location: {href: "scheduling.html?tutorID=thegoogler%40google.com&start=480&end=540&year=2020&month=5&day=18", search: "?tutorID=thegoogler%40google.com&start=480&end=540&year=2020&month=5&day=18"}};
+        var mockWindow = {location: {href: "scheduling.html?tutorID=123&start=480&end=540&year=2020&month=5&day=18", search: "?tutorID=123&start=480&end=540&year=2020&month=5&day=18"}};
         var queryString = new Array();
         readComponents(queryString, mockWindow);
 
         it("should add tutorID, start, end, year, month, and day to the query string", function() {
-            expect(queryString["tutorID"]).toEqual("thegoogler@google.com");
+            expect(queryString["tutorID"]).toEqual("123");
             expect(queryString["start"]).toEqual("480");
             expect(queryString["end"]).toEqual("540");
             expect(queryString["year"]).toEqual("2020");
@@ -42,11 +42,14 @@ describe("Scheduling", function() {
     });
 
     describe("when a user submits the form", function() {
-        var mockWindow = {location: {href: "scheduling.html"}};
+        var mockWindow = {location: {href: "scheduling.html?tutorID=123&start=480&end=540&year=2020&month=5&day=18", search: "?tutorID=123&start=480&end=540&year=2020&month=5&day=18"}};
 
-        it("should redirect the user to confirmation.html and pass tutorID as an URI component", function() {
-            redirectToConfirmation("123", mockWindow);
-            expect(mockWindow.location.href).toEqual("confirmation.html?studentID=123");
+        it("should redirect the user to confirmation.html ", async function() {
+            spyOn(window, 'fetch').and.returnValue(Promise.resolve({json: () => Promise.resolve([])}));
+            spyOn(document, "getElementById").and.returnValue("");
+
+            await scheduleTutorSessionHelper(mockWindow);
+            expect(mockWindow.location.href).toEqual("confirmation.html");
         });
     });
 

--- a/src/test/java/com/google/sps/AddAvailabilityTest.java
+++ b/src/test/java/com/google/sps/AddAvailabilityTest.java
@@ -14,6 +14,7 @@
 
 package com.google.sps;
 
+import com.google.utilities.TestUtilities;
 import java.io.StringWriter;
 import java.io.PrintWriter;
 import java.util.Calendar;
@@ -83,8 +84,8 @@ public final class AddAvailabilityTest {
     public void testDoPost() throws Exception {
         HttpServletRequest request = mock(HttpServletRequest.class);       
         HttpServletResponse response = mock(HttpServletResponse.class);
+        TestUtilities.setSessionId(request, "0");   
 
-        when(request.getParameter("tutorID")).thenReturn("0");
         when(request.getParameter("startHour")).thenReturn("22");
         when(request.getParameter("startMinute")).thenReturn("00");
         when(request.getParameter("endHour")).thenReturn("23");
@@ -100,7 +101,6 @@ public final class AddAvailabilityTest {
 
         servlet.doPost(request, response);
 
-        verify(request, times(1)).getParameter("tutorID");
         verify(request, times(1)).getParameter("startHour");
         verify(request, times(1)).getParameter("startMinute");
         verify(request, times(1)).getParameter("endHour");

--- a/src/test/java/com/google/sps/ConfirmationTest.java
+++ b/src/test/java/com/google/sps/ConfirmationTest.java
@@ -14,6 +14,7 @@
 
 package com.google.sps;
 
+import com.google.utilities.TestUtilities;
 import java.util.List;
 import java.util.Arrays;
 import java.util.ArrayList;
@@ -73,9 +74,8 @@ public final class ConfirmationTest {
     public void testDoGetNoSession() throws Exception {
         HttpServletRequest request = mock(HttpServletRequest.class);       
         HttpServletResponse response = mock(HttpServletResponse.class);
-
-        //there is no student with id = 10
-        when(request.getParameter("studentID")).thenReturn("10");
+        //there is no user with session id = 10
+        TestUtilities.setSessionId(request, "10");
 
         StringWriter stringWriter = new StringWriter();
         PrintWriter writer = new PrintWriter(stringWriter);
@@ -84,7 +84,6 @@ public final class ConfirmationTest {
 
         servlet.doGet(request, response);
 
-        verify(request, atLeast(1)).getParameter("studentID");
         writer.flush();
         // If the user has no scheduled sessions, the return json string should be an empty array
         Assert.assertTrue(stringWriter.toString().contains("[]"));
@@ -94,8 +93,8 @@ public final class ConfirmationTest {
     public void testDoGetWithSessions() throws Exception {
         HttpServletRequest request = mock(HttpServletRequest.class);       
         HttpServletResponse response = mock(HttpServletResponse.class);
+        TestUtilities.setSessionId(request, "2"); 
 
-        when(request.getParameter("studentID")).thenReturn("2");
 
         StringWriter stringWriter = new StringWriter();
         PrintWriter writer = new PrintWriter(stringWriter);
@@ -107,7 +106,6 @@ public final class ConfirmationTest {
         String expected = new Gson().toJson(Arrays.asList(new TutorSession("2","2", null, null,
                                                                         TimeRange.fromStartToEnd(540, 600, AUGUST182020), 14)));
 
-        verify(request, times(1)).getParameter("studentID");
         writer.flush();
         System.out.println(stringWriter.toString());
         System.out.println(expected);

--- a/src/test/java/com/google/sps/DeleteAvailabilityTest.java
+++ b/src/test/java/com/google/sps/DeleteAvailabilityTest.java
@@ -14,6 +14,7 @@
 
 package com.google.sps;
 
+import com.google.utilities.TestUtilities;
 import java.io.StringWriter;
 import java.io.PrintWriter;
 import java.util.Calendar;
@@ -84,8 +85,8 @@ public final class DeleteAvailabilityTest {
     public void testDoPost() throws Exception {
         HttpServletRequest request = mock(HttpServletRequest.class);       
         HttpServletResponse response = mock(HttpServletResponse.class);
+        TestUtilities.setSessionId(request, "4");
 
-        when(request.getParameter("tutorID")).thenReturn("4");
         when(request.getParameter("start")).thenReturn("780");
         when(request.getParameter("end")).thenReturn("840");
         when(request.getParameter("day")).thenReturn("10");
@@ -99,7 +100,6 @@ public final class DeleteAvailabilityTest {
 
         servlet.doPost(request, response);
 
-        verify(request, times(1)).getParameter("tutorID");
         verify(request, times(1)).getParameter("start");
         verify(request, times(1)).getParameter("end");
         verify(request, times(1)).getParameter("day");

--- a/src/test/java/com/google/sps/DeleteExperienceTest.java
+++ b/src/test/java/com/google/sps/DeleteExperienceTest.java
@@ -14,6 +14,7 @@
 
 package com.google.sps;
 
+import com.google.utilities.TestUtilities;
 import java.io.StringWriter;
 import java.io.PrintWriter;
 import java.util.Calendar;
@@ -69,7 +70,7 @@ public final class DeleteExperienceTest {
     public void testDoPost() throws Exception {
         HttpServletRequest request = mock(HttpServletRequest.class);       
         HttpServletResponse response = mock(HttpServletResponse.class);
-
+        
         // Adds experience entity to the local datastore
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         Entity experienceEntity = new Entity("Experience");
@@ -77,7 +78,7 @@ public final class DeleteExperienceTest {
         experienceEntity.setProperty("experience", "testing");
         datastore.put(experienceEntity);
 
-        when(request.getParameter("studentID")).thenReturn("123");
+        TestUtilities.setSessionId(request, "123");   
         when(request.getParameter("id")).thenReturn("1");
 
         StringWriter stringWriter = new StringWriter();
@@ -87,7 +88,6 @@ public final class DeleteExperienceTest {
 
         servlet.doPost(request, response);
 
-        verify(request, times(1)).getParameter("studentID");
         verify(request, times(1)).getParameter("id");
 
         String expected = "[]";
@@ -113,7 +113,7 @@ public final class DeleteExperienceTest {
         experienceEntity2.setProperty("experience", "testing");
         datastore.put(experienceEntity2);
 
-        when(request.getParameter("studentID")).thenReturn("123");
+        TestUtilities.setSessionId(request, "123");   
         when(request.getParameter("id")).thenReturn("1");
 
         StringWriter stringWriter = new StringWriter();
@@ -123,7 +123,6 @@ public final class DeleteExperienceTest {
 
         servlet.doPost(request, response);
 
-        verify(request, times(1)).getParameter("studentID");
         verify(request, times(1)).getParameter("id");
 
         String expected = new Gson()

--- a/src/test/java/com/google/sps/DeleteGoalTest.java
+++ b/src/test/java/com/google/sps/DeleteGoalTest.java
@@ -14,6 +14,7 @@
 
 package com.google.sps;
 
+import com.google.utilities.TestUtilities;
 import java.io.StringWriter;
 import java.io.PrintWriter;
 import java.util.Calendar;
@@ -77,7 +78,7 @@ public final class DeleteGoalTest {
         goalEntity.setProperty("goal", "testing");
         datastore.put(goalEntity);
 
-        when(request.getParameter("studentID")).thenReturn("123");
+        TestUtilities.setSessionId(request, "123");   
         when(request.getParameter("id")).thenReturn("1");
 
         StringWriter stringWriter = new StringWriter();
@@ -87,7 +88,6 @@ public final class DeleteGoalTest {
 
         servlet.doPost(request, response);
 
-        verify(request, times(1)).getParameter("studentID");
         verify(request, times(1)).getParameter("id");
 
         String expected = "[]";
@@ -113,7 +113,7 @@ public final class DeleteGoalTest {
         goalEntity2.setProperty("goal", "testing");
         datastore.put(goalEntity2);
 
-        when(request.getParameter("studentID")).thenReturn("123");
+        TestUtilities.setSessionId(request, "123");   
         when(request.getParameter("id")).thenReturn("1");
 
         StringWriter stringWriter = new StringWriter();
@@ -123,7 +123,6 @@ public final class DeleteGoalTest {
 
         servlet.doPost(request, response);
 
-        verify(request, times(1)).getParameter("studentID");
         verify(request, times(1)).getParameter("id");
 
         String expected = new Gson()

--- a/src/test/java/com/google/sps/DeleteTutorSessionTest.java
+++ b/src/test/java/com/google/sps/DeleteTutorSessionTest.java
@@ -14,6 +14,7 @@
 
 package com.google.sps;
 
+import com.google.utilities.TestUtilities;
 import java.io.StringWriter;
 import java.io.PrintWriter;
 import java.util.Calendar;
@@ -78,12 +79,11 @@ public final class DeleteTutorSessionTest {
                                             .build();
 
         TimeRange time = TimeRange.fromStartToEnd(540, 600, date);
-        // addScheduledTimeRange(time);
 
         HttpServletRequest request = mock(HttpServletRequest.class);       
         HttpServletResponse response = mock(HttpServletResponse.class);
+        TestUtilities.setSessionId(request, "2");
 
-        when(request.getParameter("tutorID")).thenReturn("2");
         when(request.getParameter("tutorID")).thenReturn("2");
         when(request.getParameter("start")).thenReturn("540");
         when(request.getParameter("end")).thenReturn("600");
@@ -103,7 +103,6 @@ public final class DeleteTutorSessionTest {
         servlet.doPost(request, response);
 
         verify(request, times(1)).getParameter("tutorID");
-        verify(request, times(1)).getParameter("studentID");
         verify(request, times(1)).getParameter("start");
         verify(request, times(1)).getParameter("end");
         verify(request, times(1)).getParameter("day");

--- a/src/test/java/com/google/sps/DeleteTutorSessionTest.java
+++ b/src/test/java/com/google/sps/DeleteTutorSessionTest.java
@@ -84,15 +84,6 @@ public final class DeleteTutorSessionTest {
         HttpServletResponse response = mock(HttpServletResponse.class);
         TestUtilities.setSessionId(request, "2");
 
-        when(request.getParameter("tutorID")).thenReturn("2");
-        when(request.getParameter("start")).thenReturn("540");
-        when(request.getParameter("end")).thenReturn("600");
-        when(request.getParameter("day")).thenReturn("18");
-        when(request.getParameter("month")).thenReturn("7");
-        when(request.getParameter("year")).thenReturn("2020");
-        when(request.getParameter("subtopics")).thenReturn(null);
-        when(request.getParameter("questions")).thenReturn(null);
-        when(request.getParameter("rating")).thenReturn("5");
         when(request.getParameter("id")).thenReturn("14");
 
         StringWriter stringWriter = new StringWriter();
@@ -102,15 +93,6 @@ public final class DeleteTutorSessionTest {
 
         servlet.doPost(request, response);
 
-        verify(request, times(1)).getParameter("tutorID");
-        verify(request, times(1)).getParameter("start");
-        verify(request, times(1)).getParameter("end");
-        verify(request, times(1)).getParameter("day");
-        verify(request, times(1)).getParameter("month");
-        verify(request, times(1)).getParameter("year");
-        verify(request, times(1)).getParameter("subtopics");
-        verify(request, times(1)).getParameter("questions");
-        verify(request, times(1)).getParameter("rating");
         verify(request, times(1)).getParameter("id");
 
         String unexpected = new Gson()

--- a/src/test/java/com/google/sps/ExperienceTest.java
+++ b/src/test/java/com/google/sps/ExperienceTest.java
@@ -14,6 +14,7 @@
 
 package com.google.sps;
 
+import com.google.utilities.TestUtilities;
 import java.io.StringWriter;
 import java.io.PrintWriter;
 import java.util.Calendar;
@@ -149,7 +150,7 @@ public final class ExperienceTest {
         HttpServletRequest request = mock(HttpServletRequest.class);       
         HttpServletResponse response = mock(HttpServletResponse.class);
 
-        when(request.getParameter("studentID")).thenReturn("123");
+        TestUtilities.setSessionId(request, "123");   
         when(request.getParameter("experience")).thenReturn("testing");
 
         StringWriter stringWriter = new StringWriter();
@@ -159,7 +160,6 @@ public final class ExperienceTest {
 
         servlet.doPost(request, response);
 
-        verify(request, times(1)).getParameter("studentID");
         verify(request, times(1)).getParameter("experience");
 
         String expected = new Gson()
@@ -176,7 +176,7 @@ public final class ExperienceTest {
         HttpServletRequest request = mock(HttpServletRequest.class);       
         HttpServletResponse response = mock(HttpServletResponse.class);
 
-        when(request.getParameter("studentID")).thenReturn(null);
+        TestUtilities.setSessionId(request, null);           
         when(request.getParameter("experience")).thenReturn("testing");
 
         StringWriter stringWriter = new StringWriter();
@@ -186,7 +186,6 @@ public final class ExperienceTest {
 
         servlet.doPost(request, response);
 
-        verify(request, times(1)).getParameter("studentID");
         verify(request, times(1)).getParameter("experience");
 
         String expected = "{\"error\": \"There was an error adding experience.\"}";

--- a/src/test/java/com/google/sps/GetStudentsTest.java
+++ b/src/test/java/com/google/sps/GetStudentsTest.java
@@ -14,6 +14,7 @@
 
 package com.google.sps;
 
+import com.google.utilities.TestUtilities;
 import com.google.sps.data.SampleData;
 import com.google.sps.data.Tutor;
 import com.google.sps.data.Student;
@@ -63,8 +64,7 @@ public final class GetStudentsTest {
     public void doGetReturnsError() throws IOException {
         HttpServletRequest request = mock(HttpServletRequest.class);       
         HttpServletResponse response = mock(HttpServletResponse.class); 
-
-        when(request.getParameter("tutorID")).thenReturn("");
+        TestUtilities.setSessionId(request, "");
 
         StringWriter stringWriter = new StringWriter();
         PrintWriter writer = new PrintWriter(stringWriter);
@@ -72,8 +72,6 @@ public final class GetStudentsTest {
 
         servlet.doGet(request, response);
 
-        //verify that getParameter was called
-        verify(request, times(1)).getParameter("tutorID"); 
         writer.flush(); // it may not have been flushed yet...
         
 
@@ -86,7 +84,7 @@ public final class GetStudentsTest {
         HttpServletRequest request = mock(HttpServletRequest.class);       
         HttpServletResponse response = mock(HttpServletResponse.class); 
 
-        when(request.getParameter("tutorID")).thenReturn("1");
+        TestUtilities.setSessionId(request, "1");
 
         StringWriter stringWriter = new StringWriter();
         PrintWriter writer = new PrintWriter(stringWriter);
@@ -94,8 +92,6 @@ public final class GetStudentsTest {
 
         servlet.doGet(request, response);
 
-        //verify that getParameter was called
-        verify(request, times(1)).getParameter("tutorID"); 
         writer.flush(); // it may not have been flushed yet...
         
         String expected = "[]";
@@ -107,7 +103,7 @@ public final class GetStudentsTest {
         HttpServletRequest request = mock(HttpServletRequest.class);       
         HttpServletResponse response = mock(HttpServletResponse.class); 
 
-        when(request.getParameter("tutorID")).thenReturn("0");
+        TestUtilities.setSessionId(request, "0");
 
         StringWriter stringWriter = new StringWriter();
         PrintWriter writer = new PrintWriter(stringWriter);
@@ -115,8 +111,6 @@ public final class GetStudentsTest {
 
         servlet.doGet(request, response);
 
-        //verify that getParameter was called
-        verify(request, times(1)).getParameter("tutorID"); 
         writer.flush(); // it may not have been flushed yet...
         
         ArrayList<Student> expectedStudents = new ArrayList<Student> (Arrays.asList(sample.getStudentByEmail("thegoogler@google.com"), sample.getStudentByEmail("elian@google.com")));

--- a/src/test/java/com/google/sps/GoalTest.java
+++ b/src/test/java/com/google/sps/GoalTest.java
@@ -14,6 +14,7 @@
 
 package com.google.sps;
 
+import com.google.utilities.TestUtilities;
 import java.io.StringWriter;
 import java.io.PrintWriter;
 import java.util.Calendar;
@@ -149,7 +150,7 @@ public final class GoalTest {
         HttpServletRequest request = mock(HttpServletRequest.class);       
         HttpServletResponse response = mock(HttpServletResponse.class);
 
-        when(request.getParameter("studentID")).thenReturn("123");
+        TestUtilities.setSessionId(request, "123");   
         when(request.getParameter("goal")).thenReturn("testing");
 
         StringWriter stringWriter = new StringWriter();
@@ -159,7 +160,6 @@ public final class GoalTest {
 
         servlet.doPost(request, response);
 
-        verify(request, times(1)).getParameter("studentID");
         verify(request, times(1)).getParameter("goal");
 
         String expected = new Gson()
@@ -176,7 +176,7 @@ public final class GoalTest {
         HttpServletRequest request = mock(HttpServletRequest.class);       
         HttpServletResponse response = mock(HttpServletResponse.class);
 
-        when(request.getParameter("studentID")).thenReturn(null);
+        TestUtilities.setSessionId(request, null);           
         when(request.getParameter("goal")).thenReturn("goal");
 
         StringWriter stringWriter = new StringWriter();
@@ -186,7 +186,6 @@ public final class GoalTest {
 
         servlet.doPost(request, response);
 
-        verify(request, times(1)).getParameter("studentID");
         verify(request, times(1)).getParameter("goal");
 
         String expected = "{\"error\": \"There was an error adding goal.\"}";

--- a/src/test/java/com/google/sps/HistoryTest.java
+++ b/src/test/java/com/google/sps/HistoryTest.java
@@ -14,6 +14,7 @@
 
 package com.google.sps;
 
+import com.google.utilities.TestUtilities;
 import java.util.List;
 import java.util.Calendar;
 import java.util.Arrays;
@@ -74,7 +75,7 @@ public final class HistoryTest {
         HttpServletRequest request = mock(HttpServletRequest.class);       
         HttpServletResponse response = mock(HttpServletResponse.class);
 
-        when(request.getParameter("studentID")).thenReturn("10");
+        TestUtilities.setSessionId(request, "10");
 
         StringWriter stringWriter = new StringWriter();
         PrintWriter writer = new PrintWriter(stringWriter);
@@ -83,7 +84,6 @@ public final class HistoryTest {
 
         servlet.doGet(request, response);
 
-        verify(request, atLeast(1)).getParameter("studentID");
         writer.flush();
         // If the user has no tutoring session history, the return json string should be an empty array
         Assert.assertTrue(stringWriter.toString().contains("[]"));
@@ -94,7 +94,7 @@ public final class HistoryTest {
         HttpServletRequest request = mock(HttpServletRequest.class);       
         HttpServletResponse response = mock(HttpServletResponse.class);
 
-        when(request.getParameter("studentID")).thenReturn("1");
+        TestUtilities.setSessionId(request, "1");
 
         StringWriter stringWriter = new StringWriter();
         PrintWriter writer = new PrintWriter(stringWriter);
@@ -106,7 +106,6 @@ public final class HistoryTest {
         //id of tutor and student is 1
         String expected = new Gson().toJson(new ArrayList<TutorSession> (Arrays.asList(new TutorSession("1", "1", null, null, TimeRange.fromStartToEnd(540, 600, MAY182020), 9))));
 
-        verify(request, times(1)).getParameter("studentID");
         writer.flush();
         System.out.println(stringWriter.toString());
         System.out.println(expected);

--- a/src/test/java/com/google/sps/LoginStatusTest.java
+++ b/src/test/java/com/google/sps/LoginStatusTest.java
@@ -186,9 +186,10 @@
          when(response.getWriter()).thenReturn(writer);
          when(request.getContentType()).thenReturn("application/json");
 
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         
         //so we don't have to create a new user entity
-         servlet.setRegistered(request, response, name);
+         servlet.setRegistered(request, response, name, datastore);
 
          servlet.doGet(request, response);
 

--- a/src/test/java/com/google/sps/LogoutTest.java
+++ b/src/test/java/com/google/sps/LogoutTest.java
@@ -1,0 +1,62 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps;
+
+import com.google.utilities.TestUtilities;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import static org.mockito.Mockito.*;
+import com.google.sps.servlets.LogoutServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.*;
+import javax.servlet.http.HttpSession;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+@RunWith(JUnit4.class)
+public final class LogoutTest {
+
+    private LogoutServlet servlet;
+
+    @Before
+    public void setUp() {
+        servlet = new LogoutServlet();
+    }
+
+    @Test
+    public void sessionIsInvalidated() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);       
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        HttpSession session = mock(HttpSession.class);
+        
+        when(request.getSession(false)).thenReturn(session);
+        
+        //mock the invalidate method for session
+         doAnswer(new Answer() {
+            public Object answer(InvocationOnMock invocation) {
+            when(request.getSession(false)).thenReturn(null);
+            return null;
+        }}).when(session).invalidate();
+
+         servlet.doPost(request, response);
+
+         Assert.assertNull(request.getSession(false));
+    }
+}

--- a/src/test/java/com/google/sps/RatingTest.java
+++ b/src/test/java/com/google/sps/RatingTest.java
@@ -76,7 +76,6 @@ public final class RatingTest {
         HttpServletResponse response = mock(HttpServletResponse.class);
         TestUtilities.setSessionId(request, "2");
 
-        when(request.getParameter("tutorID")).thenReturn("2");
         //id of the second hard coded tutor session
         when(request.getParameter("sessionId")).thenReturn("14");
         when(request.getParameter("rating")).thenReturn("5");
@@ -88,7 +87,6 @@ public final class RatingTest {
 
         servlet.doPost(request, response);
 
-        verify(request, atLeast(1)).getParameter("tutorID");
         verify(request, atLeast(1)).getParameter("sessionId");
         verify(request, atLeast(1)).getParameter("rating");
         writer.flush();

--- a/src/test/java/com/google/sps/RatingTest.java
+++ b/src/test/java/com/google/sps/RatingTest.java
@@ -14,6 +14,7 @@
 
 package com.google.sps;
 
+import com.google.utilities.TestUtilities;
 import java.util.List;
 import java.util.Calendar;
 import java.util.Arrays;
@@ -73,9 +74,9 @@ public final class RatingTest {
     public void testDoPost() throws IOException {
         HttpServletRequest request = mock(HttpServletRequest.class);       
         HttpServletResponse response = mock(HttpServletResponse.class);
+        TestUtilities.setSessionId(request, "2");
 
         when(request.getParameter("tutorID")).thenReturn("2");
-        when(request.getParameter("studentID")).thenReturn("2");
         //id of the second hard coded tutor session
         when(request.getParameter("sessionId")).thenReturn("14");
         when(request.getParameter("rating")).thenReturn("5");
@@ -88,7 +89,6 @@ public final class RatingTest {
         servlet.doPost(request, response);
 
         verify(request, atLeast(1)).getParameter("tutorID");
-        verify(request, atLeast(1)).getParameter("studentID");
         verify(request, atLeast(1)).getParameter("sessionId");
         verify(request, atLeast(1)).getParameter("rating");
         writer.flush();

--- a/src/test/java/com/google/sps/SchedulingTest.java
+++ b/src/test/java/com/google/sps/SchedulingTest.java
@@ -14,6 +14,7 @@
 
 package com.google.sps;
 
+import com.google.utilities.TestUtilities;
 import java.io.StringWriter;
 import java.io.PrintWriter;
 import java.util.Calendar;
@@ -75,6 +76,7 @@ public final class SchedulingTest {
     public void testDoPost() throws Exception {
         HttpServletRequest request = mock(HttpServletRequest.class);       
         HttpServletResponse response = mock(HttpServletResponse.class);
+        TestUtilities.setSessionId(request, "3");
 
         when(request.getParameter("tutorID")).thenReturn("1");
         when(request.getParameter("start")).thenReturn("480");
@@ -82,7 +84,6 @@ public final class SchedulingTest {
         when(request.getParameter("year")).thenReturn("2020");
         when(request.getParameter("month")).thenReturn("4");
         when(request.getParameter("day")).thenReturn("18");
-        when(request.getParameter("studentID")).thenReturn("3");
         when(request.getParameter("subtopics")).thenReturn("algebra");
         when(request.getParameter("questions")).thenReturn("How does it work?");
 
@@ -99,7 +100,6 @@ public final class SchedulingTest {
         verify(request, times(1)).getParameter("year");
         verify(request, times(1)).getParameter("month");
         verify(request, times(1)).getParameter("day");
-        verify(request, times(1)).getParameter("studentID");
         verify(request, times(1)).getParameter("subtopics");
         verify(request, times(1)).getParameter("questions");
 

--- a/src/test/java/com/google/sps/SessionFilterTest.java
+++ b/src/test/java/com/google/sps/SessionFilterTest.java
@@ -1,0 +1,109 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import javax.servlet.ServletContext;
+import javax.servlet.FilterConfig;
+import static org.mockito.Mockito.*;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.Cookie;
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.*;
+import com.google.sps.filters.SessionFilter;
+
+@RunWith(JUnit4.class)
+public final class SessionFilterTest { 
+
+    private String sessionId = "123";
+
+    private SessionFilter filter;
+
+    @Before
+    public void setUp() {
+
+        filter = new SessionFilter();
+
+    }
+
+    @Test
+    public void testUserPermissionsValidSession() throws IOException, ServletException {
+        ServletContext context = mock(ServletContext.class);
+        FilterConfig filterConfig = mock(FilterConfig.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);       
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        HttpSession session = mock(HttpSession.class);
+        Cookie mockCookie = mock(Cookie.class);
+
+        when(mockCookie.getName()).thenReturn("JSESSIONID");
+        when(mockCookie.getValue()).thenReturn(sessionId+".node0"); 
+        when(request.getSession(false)).thenReturn(session); 
+        when(session.getId()).thenReturn(sessionId);      
+        when(request.getCookies()).thenReturn(new Cookie[]{mockCookie}); 
+        when(filterConfig.getServletContext()).thenReturn(context);
+
+        filter.init(filterConfig);
+
+        Assert.assertTrue(filter.userHasPermissions(request, response));
+    }
+
+    @Test
+    public void testUserPermissionsNoCookie() throws IOException, ServletException {
+        ServletContext context = mock(ServletContext.class);
+        FilterConfig filterConfig = mock(FilterConfig.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);       
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        HttpSession session = mock(HttpSession.class);
+
+        when(request.getSession(false)).thenReturn(session); 
+        when(session.getId()).thenReturn(sessionId);      
+        when(request.getCookies()).thenReturn(null); 
+        when(filterConfig.getServletContext()).thenReturn(context);
+
+        filter.init(filterConfig);
+
+        Assert.assertFalse(filter.userHasPermissions(request, response));
+        verify(context, times(1)).log("Unauthorized access request");
+    }
+
+    @Test
+    public void testUserPermissionsNoSession() throws IOException, ServletException {
+        ServletContext context = mock(ServletContext.class);
+        FilterConfig filterConfig = mock(FilterConfig.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);       
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        Cookie mockCookie = mock(Cookie.class);
+
+        when(mockCookie.getName()).thenReturn("JSESSIONID");
+        when(mockCookie.getValue()).thenReturn(sessionId+".node0"); 
+        when(request.getSession(false)).thenReturn(null); 
+        when(request.getCookies()).thenReturn(new Cookie[]{mockCookie}); 
+        when(filterConfig.getServletContext()).thenReturn(context);
+
+        filter.init(filterConfig);
+
+        Assert.assertFalse(filter.userHasPermissions(request, response));
+        verify(context, times(1)).log("Unauthorized access request");
+    }
+
+}

--- a/src/test/java/com/google/utilities/TestUtilities.java
+++ b/src/test/java/com/google/utilities/TestUtilities.java
@@ -1,0 +1,37 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.utilities;
+
+import org.junit.runners.JUnit4;
+import static org.mockito.Mockito.*;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+/** Common methods used to set up tests. */
+public final class TestUtilities {
+
+    /**
+    * Sets the mock request's session id.
+    */
+    public static void setSessionId(HttpServletRequest request, String id) {
+        HttpSession session = mock(HttpSession.class);
+
+        when(request.getSession(false)).thenReturn(session); 
+        when(session.getAttribute("userId")).thenReturn(id);  
+    }
+
+}


### PR DESCRIPTION
These commits use sessions to make sure the user can only access their own pages (availability, sessions, history). By using sessions, we can prevent users from typing in a random user id as a query parameter and viewing someone else's personal data. I created a servlet filter that will intercept a request call and check if the session is valid. If it is not, it will redirect to the homepage. I also added a security constraint which will redirect users that are not logged in to log in when they try to visit personal pages. 

Lastly, I fixed up some tests and added a few tests to make sure the pages redirect when appropriate.