### PR TITLE
Remove student email field from scheduling form

### DIFF
--- a/src/main/webapp/scheduling.html
+++ b/src/main/webapp/scheduling.html
@@ -42,11 +42,6 @@
 
             <form id="scheduling-form">
                 <div class="form-group">
-                    <label for="studentEmail" class="col-sm-2 col-form-label">Email:</label>
-                    <input type="text" class="form-control" name="studentEmail" id="studentEmail" style="color: #555555;" placeholder="Your email here..." required>
-                </div>
-
-                <div class="form-group">
                     <label for="topics" class="col-sm-2 col-form-label">What topics would you like to cover?</label>
                     <textarea class="form-control" name="topics" id="topics" rows="3" placeholder="Topics you would like your tutor to cover..."></textarea>
                 </div>


### PR DESCRIPTION
The proposed commit in this PR deletes the email field from the scheduling form. The email used to be used to schedule a tutoring session for the user with that specific email but now that we use the userID to schedule a session, it is no longer necessary.