### PR TITLE
Fix session id issue

### DIFF
--- a/src/main/java/com/google/sps/filters/SessionFilter.java
+++ b/src/main/java/com/google/sps/filters/SessionFilter.java
@@ -25,7 +25,6 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
-import javax.servlet.http.Cookie;
 import javax.servlet.ServletContext;
 import java.util.stream.*;
 import java.util.Optional;
@@ -61,30 +60,11 @@ public class SessionFilter implements Filter {
     * @return boolean
     */
     public boolean userHasPermissions(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
-
-        Cookie[] cookies = request.getCookies();
-
-        //user has not logged in, no cookies have been created
-        if(cookies == null) {
-            this.context.log("Unauthorized access request");
-            return false;
-        }
-
-        String sessionId = "";
-        
-        for(Cookie cookie : cookies) {
-            if(cookie.getName().equals("JSESSIONID")) {
-                sessionId = cookie.getValue();
-                break;
-            }
-        }
     
         HttpSession session = request.getSession(false);
 
-        //The sessionId from the cookie has ".node0" as a suffix
-        if(session == null || !(session.getId()+".node0").equals(sessionId)) {
-            this.context.log("Unauthorized access request");
-			
+        if(session == null) {
+            this.context.log("Invalid session.");			
             return false;
         }
 

--- a/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/src/main/webapp/WEB-INF/appengine-web.xml
@@ -2,6 +2,7 @@
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
+  <async-session-persistence enabled="true" />
   <runtime>java8</runtime>
   <static-files>
     <!-- prevent unwanted caching when accessing via the web preview server -->

--- a/src/test/java/com/google/sps/SessionFilterTest.java
+++ b/src/test/java/com/google/sps/SessionFilterTest.java
@@ -26,7 +26,6 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
-import javax.servlet.http.Cookie;
 import java.io.IOException;
 import javax.servlet.ServletException;
 import javax.servlet.*;
@@ -53,13 +52,9 @@ public final class SessionFilterTest {
         HttpServletRequest request = mock(HttpServletRequest.class);       
         HttpServletResponse response = mock(HttpServletResponse.class);
         HttpSession session = mock(HttpSession.class);
-        Cookie mockCookie = mock(Cookie.class);
 
-        when(mockCookie.getName()).thenReturn("JSESSIONID");
-        when(mockCookie.getValue()).thenReturn(sessionId+".node0"); 
         when(request.getSession(false)).thenReturn(session); 
         when(session.getId()).thenReturn(sessionId);      
-        when(request.getCookies()).thenReturn(new Cookie[]{mockCookie}); 
         when(filterConfig.getServletContext()).thenReturn(context);
 
         filter.init(filterConfig);
@@ -68,42 +63,19 @@ public final class SessionFilterTest {
     }
 
     @Test
-    public void testUserPermissionsNoCookie() throws IOException, ServletException {
-        ServletContext context = mock(ServletContext.class);
-        FilterConfig filterConfig = mock(FilterConfig.class);
-        HttpServletRequest request = mock(HttpServletRequest.class);       
-        HttpServletResponse response = mock(HttpServletResponse.class);
-        HttpSession session = mock(HttpSession.class);
-
-        when(request.getSession(false)).thenReturn(session); 
-        when(session.getId()).thenReturn(sessionId);      
-        when(request.getCookies()).thenReturn(null); 
-        when(filterConfig.getServletContext()).thenReturn(context);
-
-        filter.init(filterConfig);
-
-        Assert.assertFalse(filter.userHasPermissions(request, response));
-        verify(context, times(1)).log("Unauthorized access request");
-    }
-
-    @Test
     public void testUserPermissionsNoSession() throws IOException, ServletException {
         ServletContext context = mock(ServletContext.class);
         FilterConfig filterConfig = mock(FilterConfig.class);
         HttpServletRequest request = mock(HttpServletRequest.class);       
         HttpServletResponse response = mock(HttpServletResponse.class);
-        Cookie mockCookie = mock(Cookie.class);
 
-        when(mockCookie.getName()).thenReturn("JSESSIONID");
-        when(mockCookie.getValue()).thenReturn(sessionId+".node0"); 
         when(request.getSession(false)).thenReturn(null); 
-        when(request.getCookies()).thenReturn(new Cookie[]{mockCookie}); 
         when(filterConfig.getServletContext()).thenReturn(context);
 
         filter.init(filterConfig);
 
         Assert.assertFalse(filter.userHasPermissions(request, response));
-        verify(context, times(1)).log("Unauthorized access request");
+        verify(context, times(1)).log("Invalid session.");
     }
 
 }


### PR DESCRIPTION
These commits fix the issue where a different session was being generated multiple times for one user that was logged in. I also removed the if statement that checked if the JSESSIONID cookie value was the same as the request's session id as it was not useful. 