### PR TITLE
Fix Manage Sessions Formatting

### DIFF
--- a/src/main/webapp/manage-sessions.js
+++ b/src/main/webapp/manage-sessions.js
@@ -59,7 +59,7 @@ function createScheduledSessionBoxManage(scheduledSession) {
     const dateElement = document.createElement('h3');
     dateElement.style.textAlign = 'left';
     dateElement.style.display = 'inline';
-    var hour = parseInt(scheduledSession.timeslot.start) / 60;
+    var hour = Math.floor(parseInt(scheduledSession.timeslot.start) / 60);
     var amOrPm = "am";
     if (hour > 12) {
         hour = hour - 12;


### PR DESCRIPTION
The commit proposed in this PR fixes the issue with the start hour in the tutoring session boxes being a float when minutes are involved. Now, the start hour should always be a whole number.