### PR TITLE
Fix

### DIFF
--- a/src/main/java/com/google/sps/servlets/SchedulingServlet.java
+++ b/src/main/java/com/google/sps/servlets/SchedulingServlet.java
@@ -101,7 +101,7 @@ public class SchedulingServlet extends HttpServlet {
 
 
         String json = new Gson().toJson(datastore.getScheduledSessionsForTutor(tutorID));
-        response.getWriter().println(json + "testTutorEmail: " + testTutorEmail + " testStudentEmail: " + testStudentEmail);
+        response.getWriter().println(json);
         return;
     }
 

--- a/src/main/java/com/google/sps/utilities/TutorSessionDatastoreService.java
+++ b/src/main/java/com/google/sps/utilities/TutorSessionDatastoreService.java
@@ -344,6 +344,8 @@ public final class TutorSessionDatastoreService {
 
         //there should only be one result
         Entity timeEntity = pq.asSingleEntity();
+        System.out.println(timeEntity);
+        System.out.println("herehere");
         //change the tutorID property to the sessionId
         //instead of deleting the TimeRange entity, we can just set the tutorID property to the sessionId to indicate that it is a scheduled session 
         timeEntity.setProperty("tutorID", String.valueOf(sessionId));

--- a/src/main/java/com/google/sps/utilities/TutorSessionDatastoreService.java
+++ b/src/main/java/com/google/sps/utilities/TutorSessionDatastoreService.java
@@ -344,8 +344,6 @@ public final class TutorSessionDatastoreService {
 
         //there should only be one result
         Entity timeEntity = pq.asSingleEntity();
-        System.out.println(timeEntity);
-        System.out.println("herehere");
         //change the tutorID property to the sessionId
         //instead of deleting the TimeRange entity, we can just set the tutorID property to the sessionId to indicate that it is a scheduled session 
         timeEntity.setProperty("tutorID", String.valueOf(sessionId));

--- a/src/main/webapp/scheduling.js
+++ b/src/main/webapp/scheduling.js
@@ -47,8 +47,6 @@ async function scheduleTutorSessionHelper(window) {
             alert("You must be signed in to schedule a tutoring session.");
             return null;
         }
-        console.log("test");
-        console.log(response);
         return response.json();
     }).then((tutors) => {
         if(tutors !== null && tutors.error) {
@@ -71,13 +69,6 @@ function addEventListeners() {
         scheduleTutorSession(window);
     });
 }
-
-
-// function scheduleTutorSession(window) {
-//     getUserId().then(function(studentID) {
-//         scheduleTutorSessionHelper(window, studentID);
-//     });
-// }
 
 // Referenced to https://www.aspsnippets.com/Articles/Redirect-to-another-Page-on-Button-Click-using-JavaScript.aspx#:~:text=Redirecting%
 // 20on%20Button%20Click%20using%20JavaScript&text=Inside%20the%20Send%20JavaScript%20function,is%20redirected%20to%20the%20URL on June 23rd.

--- a/src/main/webapp/scheduling.js
+++ b/src/main/webapp/scheduling.js
@@ -47,6 +47,8 @@ async function scheduleTutorSessionHelper(window) {
             alert("You must be signed in to schedule a tutoring session.");
             return null;
         }
+        console.log("test");
+        console.log(response);
         return response.json();
     }).then((tutors) => {
         if(tutors !== null && tutors.error) {
@@ -71,11 +73,11 @@ function addEventListeners() {
 }
 
 
-function scheduleTutorSession(window) {
-    getUserId().then(function(studentID) {
-        scheduleTutorSessionHelper(window, studentID);
-    });
-}
+// function scheduleTutorSession(window) {
+//     getUserId().then(function(studentID) {
+//         scheduleTutorSessionHelper(window, studentID);
+//     });
+// }
 
 // Referenced to https://www.aspsnippets.com/Articles/Redirect-to-another-Page-on-Button-Click-using-JavaScript.aspx#:~:text=Redirecting%
 // 20on%20Button%20Click%20using%20JavaScript&text=Inside%20the%20Send%20JavaScript%20function,is%20redirected%20to%20the%20URL on June 23rd.

--- a/src/test/java/com/google/sps/SchedulingTest.java
+++ b/src/test/java/com/google/sps/SchedulingTest.java
@@ -113,8 +113,8 @@ public final class SchedulingTest {
         writer.flush();
         // Tutoring session should have been scheduled
         Assert.assertTrue(stringWriter.toString().contains(expected));
-        Assert.assertTrue(stringWriter.toString().contains("testTutorEmail: true"));
-        Assert.assertTrue(stringWriter.toString().contains("testStudentEmail: true"));
+        //Assert.assertTrue(stringWriter.toString().contains("testTutorEmail: true"));
+        //Assert.assertTrue(stringWriter.toString().contains("testStudentEmail: true"));
     }
 
 }


### PR DESCRIPTION
The commits proposed in this PR fix an issue with scheduling. Because the function that calls the scheduling servlet want to transform the response back into a json, the response must be a valid json otherwise the compiler will return an error. This is what the issue was: the response coming from scheduling servlet contained trailing strings used for testing that did not comply with the json format. These strings have been removed. A duplicate of the scheduleTutorSession function has also been removed.