### PR TITLE
Hid the login logout buttons by default and let the function inside r…

### DIFF
--- a/src/main/webapp/availability.html
+++ b/src/main/webapp/availability.html
@@ -47,8 +47,8 @@
                                 <li><a id="tutor-session-settings">Manage Tutoring Sessions</a></li>
                             </ul>
                         </li>
-                        <li id="login"><a id="login-url"><span class="glyphicon glyphicon-user"></span> Login</a></li>
-                        <li id="logout"><a id="logout-url"><span class="glyphicon glyphicon-log-in"></span> Logout</a></li>
+                        <li id="login" style="display: none"><a id="login-url"><span class="glyphicon glyphicon-user"></span> Login</a></li>
+                        <li id="logout" style="display: none"><a id="logout-url"><span class="glyphicon glyphicon-log-in"></span> Logout</a></li>
                     </ul>
                 </div>
             </div>

--- a/src/main/webapp/confirmation.html
+++ b/src/main/webapp/confirmation.html
@@ -47,8 +47,8 @@
                                 <li><a id="tutor-session-settings">Manage Tutoring Sessions</a></li>
                             </ul>
                         </li>
-                        <li id="login"><a id="login-url"><span class="glyphicon glyphicon-user"></span> Login</a></li>
-                        <li id="logout"><a id="logout-url"><span class="glyphicon glyphicon-log-in"></span> Logout</a></li>
+                        <li id="login" style="display: none"><a id="login-url"><span class="glyphicon glyphicon-user"></span> Login</a></li>
+                        <li id="logout" style="display: none"><a id="logout-url"><span class="glyphicon glyphicon-log-in"></span> Logout</a></li>
                     </ul>
                 </div>
             </div>

--- a/src/main/webapp/history.html
+++ b/src/main/webapp/history.html
@@ -44,8 +44,8 @@
                                 <li><a id="tutor-session-settings">Manage Tutoring Sessions</a></li>
                             </ul>
                         </li>
-                        <li id="login"><a id="login-url"><span class="glyphicon glyphicon-user"></span> Login</a></li>
-                        <li id="logout"><a id="logout-url"><span class="glyphicon glyphicon-log-in"></span> Logout</a></li>
+                        <li id="login" style="display: none"><a id="login-url"><span class="glyphicon glyphicon-user"></span> Login</a></li>
+                        <li id="logout" style="display: none"><a id="logout-url"><span class="glyphicon glyphicon-log-in"></span> Logout</a></li>
                     </ul>
                 </div>
             </div>

--- a/src/main/webapp/homepage.html
+++ b/src/main/webapp/homepage.html
@@ -45,8 +45,8 @@ See the License for the specific language governing permissions and
                                 <li><a id="tutor-session-settings">Manage Tutoring Sessions</a></li>
                             </ul>
                         </li>
-                        <li id="login"><a id="login-url"><span class="glyphicon glyphicon-user"></span> Login</a></li>
-                        <li id="logout"><a id="logout-url"><span class="glyphicon glyphicon-log-in"></span> Logout</a></li>
+                        <li id="login" style="display: none"><a id="login-url"><span class="glyphicon glyphicon-user"></span> Login</a></li>
+                        <li id="logout" style="display: none"><a id="logout-url"><span class="glyphicon glyphicon-log-in"></span> Logout</a></li>
                     </ul>
                 </div>
             </div>

--- a/src/main/webapp/manage-availability.html
+++ b/src/main/webapp/manage-availability.html
@@ -44,8 +44,8 @@
                                 <li><a id="tutor-session-settings">Manage Tutoring Sessions</a></li>
                             </ul>
                         </li>
-                        <li id="login"><a id="login-url"><span class="glyphicon glyphicon-user"></span> Login</a></li>
-                        <li id="logout"><a id="logout-url"><span class="glyphicon glyphicon-log-in"></span> Logout</a></li>
+                        <li id="login" style="display: none"><a id="login-url"><span class="glyphicon glyphicon-user"></span> Login</a></li>
+                        <li id="logout" style="display: none"><a id="logout-url"><span class="glyphicon glyphicon-log-in"></span> Logout</a></li>
                     </ul>
                 </div>
             </div>

--- a/src/main/webapp/manage-sessions.html
+++ b/src/main/webapp/manage-sessions.html
@@ -44,8 +44,8 @@
                                 <li><a id="tutor-session-settings">Manage Tutoring Sessions</a></li>
                             </ul>
                         </li>
-                        <li id="login"><a id="login-url"><span class="glyphicon glyphicon-user"></span> Login</a></li>
-                        <li id="logout"><a id="logout-url"><span class="glyphicon glyphicon-log-in"></span> Logout</a></li>
+                        <li id="login" style="display: none"><a id="login-url"><span class="glyphicon glyphicon-user"></span> Login</a></li>
+                        <li id="logout" style="display: none"><a id="logout-url"><span class="glyphicon glyphicon-log-in"></span> Logout</a></li>
                     </ul>
                 </div>
             </div>

--- a/src/main/webapp/my-students.html
+++ b/src/main/webapp/my-students.html
@@ -45,8 +45,8 @@
                                 <li><a id="tutor-session-settings">Manage Tutoring Sessions</a></li>
                             </ul>
                         </li>
-                        <li id="login"><a id="login-url"><span class="glyphicon glyphicon-user"></span> Login</a></li>
-                        <li id="logout"><a id="logout-url"><span class="glyphicon glyphicon-log-in"></span> Logout</a></li>
+                        <li id="login" style="display: none"><a id="login-url"><span class="glyphicon glyphicon-user"></span> Login</a></li>
+                        <li id="logout" style="display: none"><a id="logout-url"><span class="glyphicon glyphicon-log-in"></span> Logout</a></li>
                     </ul>
                 </div>
             </div>

--- a/src/main/webapp/profile.html
+++ b/src/main/webapp/profile.html
@@ -46,8 +46,8 @@ See the License for the specific language governing permissions and
                                 <li><a id="tutor-session-settings">Manage Tutoring Sessions</a></li>
                             </ul>
                         </li>
-                        <li id="login"><a id="login-url"><span class="glyphicon glyphicon-user"></span> Login</a></li>
-                        <li id="logout"><a id="logout-url"><span class="glyphicon glyphicon-log-in"></span> Logout</a></li>
+                        <li id="login" style="display: none"><a id="login-url"><span class="glyphicon glyphicon-user"></span> Login</a></li>
+                        <li id="logout" style="display: none"><a id="logout-url"><span class="glyphicon glyphicon-log-in"></span> Logout</a></li>
                     </ul>
                 </div>
             </div>

--- a/src/main/webapp/registration.html
+++ b/src/main/webapp/registration.html
@@ -46,8 +46,8 @@ See the License for the specific language governing permissions and
                                 <li><a id="tutor-session-settings">Manage Tutoring Sessions</a></li>
                             </ul>
                         </li>
-                        <li id="login"><a id="login-url"><span class="glyphicon glyphicon-user"></span> Login</a></li>
-                        <li id="logout"><a id="logout-url"><span class="glyphicon glyphicon-log-in"></span> Logout</a></li>
+                        <li id="login" style="display: none"><a id="login-url"><span class="glyphicon glyphicon-user"></span> Login</a></li>
+                        <li id="logout" style="display: none"><a id="logout-url"><span class="glyphicon glyphicon-log-in"></span> Logout</a></li>
                     </ul>
                 </div>
             </div>

--- a/src/main/webapp/scheduling.html
+++ b/src/main/webapp/scheduling.html
@@ -47,8 +47,8 @@
                                 <li><a id="tutor-session-settings">Manage Tutoring Sessions</a></li>
                             </ul>
                         </li>
-                        <li id="login"><a id="login-url"><span class="glyphicon glyphicon-user"></span> Login</a></li>
-                        <li id="logout"><a id="logout-url"><span class="glyphicon glyphicon-log-in"></span> Logout</a></li>
+                        <li id="login" style="display: none"><a id="login-url"><span class="glyphicon glyphicon-user"></span> Login</a></li>
+                        <li id="logout" style="display: none"><a id="logout-url"><span class="glyphicon glyphicon-log-in"></span> Logout</a></li>
                     </ul>
                 </div>
             </div>

--- a/src/main/webapp/search-results.html
+++ b/src/main/webapp/search-results.html
@@ -44,8 +44,8 @@ See the License for the specific language governing permissions and
                                 <li><a id="tutor-session-settings">Manage Tutoring Sessions</a></li>
                             </ul>
                         </li>
-                        <li id="login"><a id="login-url"><span class="glyphicon glyphicon-user"></span> Login</a></li>
-                        <li id="logout"><a id="logout-url"><span class="glyphicon glyphicon-log-in"></span> Logout</a></li>
+                        <li id="login" style="display: none"><a id="login-url"><span class="glyphicon glyphicon-user"></span> Login</a></li>
+                        <li id="logout" style="display: none"><a id="logout-url"><span class="glyphicon glyphicon-log-in"></span> Logout</a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
The commits proposed in this PR hide the login logout buttons by default and let the function inside registration.js handle their display. The reason behind this is that, because their display was set to block by default, both buttons were being displayed in cases in which the registration.js file took longer to load.