### PR TITLE
Remove Progress Tab from NavBar

### DIFF
--- a/src/main/webapp/availability.html
+++ b/src/main/webapp/availability.html
@@ -43,7 +43,6 @@
                                 <li><a id="history">History</a></li>
                                 <li><a id="availability-settings">Manage Availability</a></li>
                                 <li><a id="my-students">My Students</a></li>
-                                <li><a id="my-progress">My Progress</a></li>
                                 <li><a id="tutor-session-settings">Manage Tutoring Sessions</a></li>
                             </ul>
                         </li>

--- a/src/main/webapp/confirmation.html
+++ b/src/main/webapp/confirmation.html
@@ -43,7 +43,6 @@
                                 <li><a id="history">History</a></li>
                                 <li><a id="availability-settings">Manage Availability</a></li>
                                 <li><a id="my-students">My Students</a></li>
-                                <li><a id="my-progress">My Progress</a></li>
                                 <li><a id="tutor-session-settings">Manage Tutoring Sessions</a></li>
                             </ul>
                         </li>

--- a/src/main/webapp/history.html
+++ b/src/main/webapp/history.html
@@ -40,7 +40,6 @@
                                 <li><a id="history">History</a></li>
                                 <li><a id="availability-settings">Manage Availability</a></li>
                                 <li><a id="my-students">My Students</a></li>
-                                <li><a id="my-progress">My Progress</a></li>
                                 <li><a id="tutor-session-settings">Manage Tutoring Sessions</a></li>
                             </ul>
                         </li>

--- a/src/main/webapp/homepage.html
+++ b/src/main/webapp/homepage.html
@@ -41,7 +41,6 @@ See the License for the specific language governing permissions and
                                 <li><a id="history">History</a></li>
                                 <li><a id="availability-settings">Manage Availability</a></li>
                                 <li><a id="my-students">My Students</a></li>
-                                <li><a id="my-progress">My Progress</a></li>
                                 <li><a id="tutor-session-settings">Manage Tutoring Sessions</a></li>
                             </ul>
                         </li>

--- a/src/main/webapp/manage-availability.html
+++ b/src/main/webapp/manage-availability.html
@@ -40,7 +40,6 @@
                                 <li><a id="history">History</a></li>
                                 <li><a id="availability-settings">Manage Availability</a></li>
                                 <li><a id="my-students">My Students</a></li>
-                                <li><a id="my-progress">My Progress</a></li>
                                 <li><a id="tutor-session-settings">Manage Tutoring Sessions</a></li>
                             </ul>
                         </li>

--- a/src/main/webapp/manage-sessions.html
+++ b/src/main/webapp/manage-sessions.html
@@ -40,7 +40,6 @@
                                 <li><a id="history">History</a></li>
                                 <li><a id="availability-settings">Manage Availability</a></li>
                                 <li><a id="my-students">My Students</a></li>
-                                <li><a id="my-progress">My Progress</a></li>
                                 <li><a id="tutor-session-settings">Manage Tutoring Sessions</a></li>
                             </ul>
                         </li>

--- a/src/main/webapp/my-students.html
+++ b/src/main/webapp/my-students.html
@@ -41,7 +41,6 @@
                                 <li><a id="history">History</a></li>
                                 <li><a id="availability-settings">Manage Availability</a></li>
                                 <li><a id="my-students">My Students</a></li>
-                                <li><a id="my-progress">My Progress</a></li>
                                 <li><a id="tutor-session-settings">Manage Tutoring Sessions</a></li>
                             </ul>
                         </li>

--- a/src/main/webapp/profile.html
+++ b/src/main/webapp/profile.html
@@ -42,7 +42,6 @@ See the License for the specific language governing permissions and
                                 <li><a id="history">History</a></li>
                                 <li><a id="availability-settings">Manage Availability</a></li>
                                 <li><a id="my-students">My Students</a></li>
-                                <li><a id="my-progress">My Progress</a></li>
                                 <li><a id="tutor-session-settings">Manage Tutoring Sessions</a></li>
                             </ul>
                         </li>

--- a/src/main/webapp/registration.html
+++ b/src/main/webapp/registration.html
@@ -42,7 +42,6 @@ See the License for the specific language governing permissions and
                                 <li><a id="history">History</a></li>
                                 <li><a id="availability-settings">Manage Availability</a></li>
                                 <li><a id="my-students">My Students</a></li>
-                                <li><a id="my-progress">My Progress</a></li>
                                 <li><a id="tutor-session-settings">Manage Tutoring Sessions</a></li>
                             </ul>
                         </li>

--- a/src/main/webapp/registration.js
+++ b/src/main/webapp/registration.js
@@ -78,7 +78,6 @@ function displayLoginLogoutLinkHelper(document, loginStatus) {
         if (loginStatus.role == "tutor") {
             document.getElementById('availability-settings').style.display = "block";
             document.getElementById('my-students').style.display = "block";
-            document.getElementById('my-progress').style.display = "none";
             document.getElementById('tutor-session-settings').style.display = "none";
             document.getElementById('history').style.display = "none";
             document.getElementById('availability-settings').addEventListener('click', () => {
@@ -91,7 +90,6 @@ function displayLoginLogoutLinkHelper(document, loginStatus) {
         } else if (loginStatus.role == "student") {
             document.getElementById('availability-settings').style.display = "none";
             document.getElementById('my-students').style.display = "none";
-            document.getElementById('my-progress').style.display = "block";
             document.getElementById('tutor-session-settings').style.display = "block";
             document.getElementById('history').style.display = "block";
             document.getElementById('tutor-session-settings').addEventListener('click', () => {
@@ -99,9 +97,6 @@ function displayLoginLogoutLinkHelper(document, loginStatus) {
             });
             document.getElementById('history').addEventListener('click', () => {
                 redirectToHistory(window, loginStatus);
-            });
-            document.getElementById('my-progress').addEventListener('click', () => {
-                redirectProgress(window, loginStatus);
             });
         }
     }
@@ -159,14 +154,6 @@ function redirectToManageSessions(window, loginStatus) {
  */
 function redirectToHistory(window, loginStatus) {
     var url = "history.html";
-    window.location.href = url;
-}
-
-/**
- * Sets the URL's query string for the user's profile to their user ID and redirect them to progress.html
- */
-function redirectProgress(window, loginStatus) {
-    var url = "progress.html?studentID=" + encodeURIComponent(loginStatus.userId);
     window.location.href = url;
 }
 

--- a/src/main/webapp/scheduling.html
+++ b/src/main/webapp/scheduling.html
@@ -43,7 +43,6 @@
                                 <li><a id="history">History</a></li>
                                 <li><a id="availability-settings">Manage Availability</a></li>
                                 <li><a id="my-students">My Students</a></li>
-                                <li><a id="my-progress">My Progress</a></li>
                                 <li><a id="tutor-session-settings">Manage Tutoring Sessions</a></li>
                             </ul>
                         </li>

--- a/src/main/webapp/search-results.html
+++ b/src/main/webapp/search-results.html
@@ -40,7 +40,6 @@ See the License for the specific language governing permissions and
                                 <li><a id="history">History</a></li>
                                 <li><a id="availability-settings">Manage Availability</a></li>
                                 <li><a id="my-students">My Students</a></li>
-                                <li><a id="my-progress">My Progress</a></li>
                                 <li><a id="tutor-session-settings">Manage Tutoring Sessions</a></li>
                             </ul>
                         </li>

--- a/src/main/webapp/webapptests/spec/SpecRegistration.js
+++ b/src/main/webapp/webapptests/spec/SpecRegistration.js
@@ -141,9 +141,6 @@ describe("Registration", function() {
                 var mockMyStudentsLink = document.createElement('button');
                 mockMyStudentsLink.id = 'my-students';
 
-                var mockMyProgressLink = document.createElement('button');
-                mockMyProgressLink.id = 'my-progress';
-
                 var mockTutorSessionSettingsLink = document.createElement('button');
                 mockTutorSessionSettingsLink.id = 'tutor-session-settings';
 
@@ -160,7 +157,6 @@ describe("Registration", function() {
                 document.body.appendChild(mockProfileLink);
                 document.body.appendChild(mockAvailabilitySettingsLink);
                 document.body.appendChild(mockMyStudentsLink);
-                document.body.appendChild(mockMyProgressLink);
                 document.body.appendChild(mockTutorSessionSettingsLink);
                 document.body.appendChild(mockHistoryLink);
                 document.body.appendChild(mockDropdownLink);
@@ -184,7 +180,6 @@ describe("Registration", function() {
                 expect(document.getElementById('profile').style.display).toBe('block');
                 expect(document.getElementById('availability-settings').style.display).toBe('none');
                 expect(document.getElementById('my-students').style.display).toBe('none');
-                expect(document.getElementById('my-progress').style.display).toBe('block');
                 expect(document.getElementById('tutor-session-settings').style.display).toBe('block');
                 expect(document.getElementById('history').style.display).toBe('block');
                 expect(document.getElementById('account-dropdown').style.display).toBe('block');
@@ -199,7 +194,6 @@ describe("Registration", function() {
                 expect(document.getElementById('profile').style.display).toBe('block');
                 expect(document.getElementById('availability-settings').style.display).toBe('block');
                 expect(document.getElementById('my-students').style.display).toBe('block');
-                expect(document.getElementById('my-progress').style.display).toBe('none');
                 expect(document.getElementById('tutor-session-settings').style.display).toBe('none');
                 expect(document.getElementById('history').style.display).toBe('none');
                 expect(document.getElementById('account-dropdown').style.display).toBe('block');
@@ -248,14 +242,6 @@ describe("Registration", function() {
                 redirectToMyStudents(mockWindow, mockLoginStatus);
 
                 expect(mockWindow.location.href).toEqual("my-students.html");
-            })
-
-            it("adds event listener that redirects the user to their progress", function() {
-                mockLoginStatus = {isLoggedIn:false, needsToRegister:false, url:'/_ah/login?continue=%2Fregistration.html', userId:'123'};
-                var mockWindow = {location: {href: "homepage.html"}};
-                redirectProgress(mockWindow, mockLoginStatus);
-
-                expect(mockWindow.location.href).toEqual("progress.html?studentID=123");
             })
 
             it("adds event listener that redirects the user to their tutor session settings", function() {


### PR DESCRIPTION
The commits proposed in this PR remove the my progress option from the navigation bar. Changes also include removing calls to my-progress inside registering.js and updating the jasmine tests.