### PR TITLE
Add option to view a tutor's availability from their profile

### DIFF
--- a/src/main/webapp/profile.html
+++ b/src/main/webapp/profile.html
@@ -140,7 +140,7 @@ See the License for the specific language governing permissions and
             </div>
 
             <div class="container-fluid bg-white text-center" id="tutor-availability" style="display:none"> 
-                <button type="button" class="btn btn-lg" id="tutor-availability-btn" style="display:none">View Availability</button>
+                <button type="button" class="btn btn-lg" id="tutor-availability-btn">View Availability</button>
             </div>
 
             <div class="container-fluid text-center bg-white" id="list-container-profile" style="display:none">

--- a/src/main/webapp/profile.html
+++ b/src/main/webapp/profile.html
@@ -62,10 +62,12 @@ See the License for the specific language governing permissions and
                 </div>
             </div>
         </nav>
+
         <div class="bg-white-lg">
             <div class="container-fluid bg-white text-center" id="profile-container" style="display:none">
                 <button type="button" class="btn btn-lg" id="edit-profile-btn" style="display:none">Edit Profile</button>
             </div>
+
             <div class="container-fluid bg-white" id="edit-profile-form" style="display:none">
                 <form action="/profile" method="POST">
                     <label for="bio">Biography:</label><br>
@@ -136,6 +138,11 @@ See the License for the specific language governing permissions and
                     <ul class="list-group text-left" id="past-topics"></ul>
                 </div>
             </div>
+
+            <div class="container-fluid bg-white text-center" id="tutor-availability" style="display:none"> 
+                <button type="button" class="btn btn-lg" id="tutor-availability-btn" style="display:none">View Availability</button>
+            </div>
+
             <div class="container-fluid text-center bg-white" id="list-container-profile" style="display:none">
                     <h3>My Lists</h3>
                     <div class="list-group col-md-4" id="list-names" style="margin-top:3%"></div>

--- a/src/main/webapp/profile.js
+++ b/src/main/webapp/profile.js
@@ -96,6 +96,11 @@ function fetchStatusHelper(user, loginStatus, window, document) {
         var listWithSpaces = removeBlank.replace(/,/g, ', ');
         text = "I am tutoring in: " + listWithSpaces;
         getListsProfile();
+
+        document.getElementById('tutor-availability').style.display = 'block';
+        document.getElementById('tutor-availability-btn').addEventListener('click', () => {
+            redirectToAvailability(user, window); 
+        });
     }
 
     if (loginStatus.userId == getIdParameter(window)) {
@@ -198,4 +203,17 @@ function editProfile(user, role, document) {
         }
         document.getElementById('other-subject').value = otherTopics.join(', ');
     }
+}
+
+function redirectToAvailability(user, window) {
+    var url;
+
+    // If the user is both a tutor and a student
+    if (user.student != null) {
+        url = "availability.html?tutorID=" + user.tutor.userId;
+    } else {
+        url = "availability.html?tutorID=" + user.userId;
+    }
+
+    window.location.href = url;
 }

--- a/src/main/webapp/webapptests/spec/SpecProfile.js
+++ b/src/main/webapp/webapptests/spec/SpecProfile.js
@@ -95,13 +95,11 @@ describe("User Profile", function() {
         });
 
         it("should set p to the correct topics", function() {
-            spyOn(window, "getListsProfile");
             actualText = fetchStatusHelper(mockUser, mockLoginStatus, mockWindow, document);
             expect(actualText).toEqual("I am tutoring in: Math, Physics");
         });
 
         it("should set make the tutor availability button visible", function() {
-            spyOn(window, "getListsProfile");
             fetchStatusHelper(mockUser, mockLoginStatus, mockWindow, document);
             expect(document.getElementById('tutor-availability').style.display).toBe('block');
         });

--- a/src/main/webapp/webapptests/spec/SpecProfile.js
+++ b/src/main/webapp/webapptests/spec/SpecProfile.js
@@ -25,9 +25,18 @@ describe("User Profile", function() {
         beforeAll(function() {
             var mockEditButton = document.createElement('btn');
             mockEditButton.style.display = 'none';
-            mockEditButton.id = "edit-profile-btn"
+            mockEditButton.id = "edit-profile-btn";
+
+            var mockAvailability = document.createElement('div');
+            mockAvailability.style.display = 'none';
+            mockAvailability.id = "tutor-availability";
+
+            var mockAvailabilityButton = document.createElement('btn');
+            mockAvailabilityButton.id = "tutor-availability-btn";
 
             document.body.appendChild(mockEditButton);
+            document.body.appendChild(mockAvailability);
+            document.body.appendChild(mockAvailabilityButton);
             
             spyOn(window, 'addEventListeners');
             spyOn(window, 'getExperiences');
@@ -35,6 +44,7 @@ describe("User Profile", function() {
             spyOn(window, 'getAchievements');
             spyOn(window, 'getPastSessionsAndTopics')
             
+            spyOn(window, "getListsProfile");
             actualDiv = createProfileDiv(mockUser, {role: "tutor", userId: "123"});
 
             actualText = fetchStatusHelper(mockUser, mockLoginStatus, mockWindow, document);
@@ -85,8 +95,23 @@ describe("User Profile", function() {
         });
 
         it("should set p to the correct topics", function() {
-
+            spyOn(window, "getListsProfile");
+            actualText = fetchStatusHelper(mockUser, mockLoginStatus, mockWindow, document);
             expect(actualText).toEqual("I am tutoring in: Math, Physics");
+        });
+
+        it("should set make the tutor availability button visible", function() {
+            spyOn(window, "getListsProfile");
+            fetchStatusHelper(mockUser, mockLoginStatus, mockWindow, document);
+            expect(document.getElementById('tutor-availability').style.display).toBe('block');
+        });
+
+        it("adds event listener that redirects the user to the tutor's availability", function() {
+            var mockWindow = {location: {href: "profile.html"}};
+            var mockUser = {userId: "123"};
+            redirectToAvailability(mockUser, mockWindow);
+
+            expect(mockWindow.location.href).toEqual("availability.html?tutorID=123");
         });
     });
 


### PR DESCRIPTION
The commits proposed in this PR add a button that is displayed on a tutor's profile that redirects the user to that given tutor's availability. I have added the appropriate jasmine tests to SpecProfile.js.