### PR TITLE
Allow users to sort by rating

### DIFF
--- a/src/main/java/com/google/sps/data/SampleData.java
+++ b/src/main/java/com/google/sps/data/SampleData.java
@@ -175,6 +175,25 @@ public final class SampleData {
     }
 
     /**
+    * Adds all sample User objects to datastore.
+    */
+    public void addUsersToDatastore() {
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+
+        for (User user : users) {
+            Entity entity = new Entity("User");
+            entity.setProperty("userId", user.getUserId());
+
+            String fullName = user.getName();
+            entity.setProperty("fullName", fullName.toLowerCase());
+            String[] nameSplit = fullName.split(" ", 2); 
+            entity.setProperty("firstName", nameSplit[0].toLowerCase());
+            entity.setProperty("lastName", nameSplit[1].toLowerCase());
+            datastore.put(entity);
+        }
+    }
+
+    /**
     * Rates a sample tutor with the given rating.
     */
     public void rateTutor(String userId, int rating) {

--- a/src/main/java/com/google/sps/data/SampleData.java
+++ b/src/main/java/com/google/sps/data/SampleData.java
@@ -215,6 +215,9 @@ public final class SampleData {
         tutorEntity.setProperty("rating", Math.round(ratingSum/ratingCount));
 
         datastore.put(tutorEntity);
+
+        Tutor tutor = getTutorByEmail((String) tutorEntity.getProperty("email"));
+        tutor.addRating(rating);
     }
 
     private void addTutorAvailabilityToDatastore(DatastoreService datastore, ArrayList<TimeRange> times, String userId) {

--- a/src/main/java/com/google/sps/data/SampleData.java
+++ b/src/main/java/com/google/sps/data/SampleData.java
@@ -17,6 +17,11 @@ package com.google.sps.data;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.appengine.api.datastore.Query.Filter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -121,6 +126,9 @@ public final class SampleData {
         return null;
     }
 
+    /**
+    * Adds all the sample Tutor objects to datastore.
+    */
     public void addTutorsToDatastore() {
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
@@ -133,6 +141,7 @@ public final class SampleData {
             entity.setProperty("topics", tutor.getSkills());
             entity.setProperty("ratingSum", 0);
             entity.setProperty("ratingCount", 0);
+            entity.setProperty("rating", 0);
             entity.setProperty("userId", tutor.getUserId());
             datastore.put(entity);
 
@@ -141,6 +150,9 @@ public final class SampleData {
         }
     }
 
+    /**
+    * Adds all the sample Student objects to datastore.
+    */
     public void addStudentsToDatastore() {
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
@@ -155,6 +167,30 @@ public final class SampleData {
             entity.setProperty("userId", student.getUserId());
             datastore.put(entity);
         }
+    }
+
+    /**
+    * Rates a sample tutor with the given rating.
+    */
+    public void rateTutor(String userId, int rating) {
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+
+        //get tutor with user id
+        Filter filter = new FilterPredicate("userId", FilterOperator.EQUAL, userId);
+        Query query = new Query("Tutor").setFilter(filter);
+
+        PreparedQuery pq = datastore.prepare(query);
+
+        Entity tutorEntity = pq.asSingleEntity();
+
+        int ratingSum = Math.toIntExact((long) tutorEntity.getProperty("ratingSum")) + rating;
+        int ratingCount = Math.toIntExact((long) tutorEntity.getProperty("ratingCount")) + 1;
+
+        tutorEntity.setProperty("ratingSum", ratingSum);
+        tutorEntity.setProperty("ratingCount", ratingCount);
+        tutorEntity.setProperty("rating", Math.round(ratingSum/ratingCount));
+
+        datastore.put(tutorEntity);
     }
 
     private void addTutorAvailabilityToDatastore(DatastoreService datastore, ArrayList<TimeRange> times, String userId) {

--- a/src/main/java/com/google/sps/data/Tutor.java
+++ b/src/main/java/com/google/sps/data/Tutor.java
@@ -95,4 +95,12 @@ public final class Tutor {
     public String getUserId() {
         return this.userId;
     }
+
+    /**
+    * Used for testing.
+    */
+    public void addRating(int rating) {
+        this.ratingCount++;
+        this.ratingSum += rating;
+    }
 }

--- a/src/main/java/com/google/sps/servlets/RegistrationServlet.java
+++ b/src/main/java/com/google/sps/servlets/RegistrationServlet.java
@@ -141,6 +141,7 @@ public class RegistrationServlet extends HttpServlet {
     entity.setProperty("topics", topics);
     entity.setProperty("ratingSum", 0);
     entity.setProperty("ratingCount", 0);
+    entity.setProperty("rating", 0);
     entity.setProperty("userId", userId);
     ds.put(entity);
   }

--- a/src/main/java/com/google/sps/servlets/SearchServlet.java
+++ b/src/main/java/com/google/sps/servlets/SearchServlet.java
@@ -56,7 +56,9 @@ public class SearchServlet extends HttpServlet {
             return;
         }
 
-        List<Tutor> results = datastore.getTutorsForTopic(topic, studentID);
+        String sortType = Optional.ofNullable(request.getParameter("sort-type")).orElse("alpha");
+
+        List<Tutor> results = datastore.getTutorsForTopic(topic, studentID, sortType);
 
         response.setCharacterEncoding("UTF-8");
 

--- a/src/main/java/com/google/sps/servlets/SearchServlet.java
+++ b/src/main/java/com/google/sps/servlets/SearchServlet.java
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0 
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/sps/utilities/SearchDatastoreService.java
+++ b/src/main/java/com/google/sps/utilities/SearchDatastoreService.java
@@ -29,6 +29,7 @@ import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.FilterOperator;
 import com.google.appengine.api.datastore.Query.FilterPredicate;
 import com.google.appengine.api.datastore.Query.Filter;
+import com.google.appengine.api.datastore.Query.SortDirection;
 import java.lang.String;
 import java.util.Collection;
 import java.util.ArrayList;
@@ -44,11 +45,19 @@ public final class SearchDatastoreService {
     * it should not return that tutor in results.
     * @return List<Tutor>
     */
-    public List<Tutor> getTutorsForTopic(String topic, String studentID) {
+    public List<Tutor> getTutorsForTopic(String topic, String studentID, String sortType) {
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
         Filter topicFilter = new FilterPredicate("topics", FilterOperator.EQUAL, topic.toLowerCase());
         Query tutorQuery = new Query("Tutor").setFilter(topicFilter);
+
+        switch(sortType) {
+            case "rating":
+                tutorQuery.addSort("rating", SortDirection.DESCENDING);
+                break;
+            default:
+                tutorQuery.addSort("name", SortDirection.ASCENDING);
+        }
 
         ArrayList<Tutor> tutors = new ArrayList<Tutor>();
 

--- a/src/main/java/com/google/sps/utilities/SearchDatastoreService.java
+++ b/src/main/java/com/google/sps/utilities/SearchDatastoreService.java
@@ -51,7 +51,7 @@ public final class SearchDatastoreService {
         Filter topicFilter = new FilterPredicate("topics", FilterOperator.EQUAL, topic.toLowerCase());
         Query tutorQuery = new Query("Tutor").setFilter(topicFilter);
 
-        switch(sortType) {
+        switch(sortType.toLowerCase()) {
             case "rating":
                 tutorQuery.addSort("rating", SortDirection.DESCENDING);
                 break;
@@ -99,7 +99,7 @@ public final class SearchDatastoreService {
         ArrayList<TutorSession> sessions = new ArrayList<TutorSession>();
 
         //get all sessions with user id
-        Filter filter = new FilterPredicate("userId", FilterOperator.EQUAL, userId);
+        Filter filter = new FilterPredicate("tutorID", FilterOperator.EQUAL, userId);
         Query query = new Query("TutorSession").setFilter(filter);
 
         PreparedQuery sessionEntities = datastore.prepare(query);

--- a/src/main/java/com/google/sps/utilities/TutorSessionDatastoreService.java
+++ b/src/main/java/com/google/sps/utilities/TutorSessionDatastoreService.java
@@ -225,11 +225,12 @@ public final class TutorSessionDatastoreService {
 
         Entity tutorEntity = pq.asSingleEntity();
 
-        int ratingSum = Math.toIntExact((long) tutorEntity.getProperty("ratingSum"));
-        int ratingCount = Math.toIntExact((long) tutorEntity.getProperty("ratingCount"));
+        int ratingSum = Math.toIntExact((long) tutorEntity.getProperty("ratingSum")) + rating;
+        int ratingCount = Math.toIntExact((long) tutorEntity.getProperty("ratingCount")) + 1;
 
-        tutorEntity.setProperty("ratingSum", ratingSum + rating);
-        tutorEntity.setProperty("ratingCount", ratingCount + 1);
+        tutorEntity.setProperty("ratingSum", ratingSum);
+        tutorEntity.setProperty("ratingCount", ratingCount);
+        tutorEntity.setProperty("rating", Math.round(ratingSum/ratingCount));
 
         datastore.put(txn, tutorEntity);
 

--- a/src/main/webapp/search-results.css
+++ b/src/main/webapp/search-results.css
@@ -14,6 +14,11 @@ See the License for the specific language governing permissions and
     width: 75%;
 }
 
+#tutor-filter {
+    position: fixed;
+    margin-left: 2%;
+}
+
 #search-form-results {
     margin:auto;
     margin-top: 2% !important;

--- a/src/main/webapp/search-results.html
+++ b/src/main/webapp/search-results.html
@@ -69,6 +69,21 @@ See the License for the specific language governing permissions and
 
         <div id="result-container bg-white" class="list-group">
             <div id="tutors" class="list-group active-container">
+                <div id="tutor-filter">
+                    <p style="margin-bottom:0; font-weight: 700;">Sort by:</p>
+                    <div class="form-check">
+                        <input class="form-check-input" type="radio" name="sort" id="alpha-sort" value="alpha" onclick="handleTutorSort(this)" checked>
+                        <label class="form-check-label" for="alpha-sort" style="font-weight:100">
+                            Alphabetical
+                        </label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input" type="radio" name="sort" id="rating-sort" value="rating" onclick="handleTutorSort(this)">
+                        <label class="form-check-label" for="rating-sort" style="font-weight:100">
+                            Rating
+                        </label>
+                    </div>
+                </div>
                 <h4 class="container-label" id="num-tutor-results"></h4>
                 <div id="tutors-container"></div>
             </div>

--- a/src/main/webapp/search.js
+++ b/src/main/webapp/search.js
@@ -25,6 +25,10 @@ function switchTab(elem) {
     elem.parentNode.classList.add("active");
 }
 
+function handleTutorSort(elem) {
+    return getSearchResultsHelper(window, elem.value);
+}
+
 /** Gets the topic the user searched for from the search box and redirects the page to the search-results page with a url that contains a query parameter for the topic. 
     The user may already be on the search-results page. In that case, the page will reload with a different value for the topic query parameter. */
 function redirectToResults() {
@@ -43,11 +47,11 @@ function redirectToResultsHelper(document, window) {
 
 /** Fetches the search results for the topic that the user searched for. */
 function getSearchResults() {
-    return getSearchResultsHelper(document, window);
+    return getSearchResultsHelper(window);
 }
 
 /** Helper function for getSearchResults, used for testing purposes. */
-async function getSearchResultsHelper(document, window) {
+async function getSearchResultsHelper(window, sort) {
     var topic;
 
     if (window.location.search.split('?').length > 0) {
@@ -56,7 +60,7 @@ async function getSearchResultsHelper(document, window) {
     }
 
     if(topic != null) {
-        var tutors = getTutors(topic);
+        var tutors = getTutors(topic, sort);
         var tutorBooks = getTutorBooks(topic);
         var googleBooks = getBooks(topic);
         
@@ -210,8 +214,11 @@ function loadMoreBooks(topic) {
 }
 
 /** Fetches the list of tutors for the topic the user searched for. */
-async function getTutors(topic) {
-    await fetch("/search?topic="+topic).then(response => response.json()).then((results) => {
+async function getTutors(topic, sort) {
+    if(sort === undefined) {
+        sort = "alpha";
+    }
+    await fetch("/search?topic=" + topic + "&sort-type=" + sort).then(response => response.json()).then((results) => {
 
         var numSearchResults = document.getElementById("num-tutor-results");
         
@@ -224,7 +231,13 @@ async function getTutors(topic) {
         //Only make "tutors" plural if there are 0 or more than 1 tutors
         numSearchResults.innerText = "Found " + results.length + (results.length > 1 || results.length === 0 ? " tutors for " : " tutor for ") + topic;
 
+        if(results.length == 0) {
+            document.getElementById("tutor-filter").style.display = "none";
+        }
+
         var tutorContainer = document.getElementById("tutors-container");
+
+        tutorContainer.innerHTML = "";
 
         results.forEach(function(result) {
             tutorContainer.append(createTutorResult(result));

--- a/src/main/webapp/webapptests/spec/SpecSearch.js
+++ b/src/main/webapp/webapptests/spec/SpecSearch.js
@@ -63,10 +63,10 @@ describe("Search", function() {
 
             spyOn(window, "createTutorListElement").and.returnValue(document.createElement("div"));
 
-            await getSearchResultsHelper(document, mockWindow);
+            await getSearchResultsHelper(mockWindow);
 
             expect(window.fetch).toHaveBeenCalledTimes(3);
-            expect(window.fetch.calls.allArgs()[0][0]).toEqual("/search?topic=math");
+            expect(window.fetch.calls.allArgs()[0][0]).toEqual("/search?topic=math&sort-type=alpha");
             expect(window.fetch.calls.allArgs()[1][0]).toEqual("/lists?topic=math");
             expect(window.fetch.calls.allArgs()[2][0]).toContain("https://www.googleapis.com/books/v1/volumes");
 
@@ -280,6 +280,18 @@ describe("Search", function() {
             expect(modalBody.childNodes[1].innerText).toBe("book 2");
         });
 
+    });
+
+    describe("when sort type is changed to rating", function() {
+        var radioButton = document.createElement("input");
+        radioButton.value = "rating";
+        it("should call getSearchResultsHelper with the correct parameters", function() {
+            spyOn(window, "getSearchResultsHelper");
+            handleTutorSort(radioButton);
+            expect(window.getSearchResultsHelper).toHaveBeenCalledTimes(1);
+            expect(window.getSearchResultsHelper.calls.allArgs()[0][1]).toEqual("rating");
+
+        });
     });
     
 });

--- a/src/test/java/com/google/sps/RegistrationTest.java
+++ b/src/test/java/com/google/sps/RegistrationTest.java
@@ -111,6 +111,7 @@ public final class RegistrationTest {
         expectedTutor.setProperty("topics", mockTopics);
         expectedTutor.setProperty("ratingSum", 0);
         expectedTutor.setProperty("ratingCount", 0);
+        expectedTutor.setProperty("rating", 0);
         expectedTutor.setProperty("userId", USER_ID);
 
         Entity actualUser = new Entity("User");

--- a/src/test/java/com/google/sps/SearchTest.java
+++ b/src/test/java/com/google/sps/SearchTest.java
@@ -60,6 +60,7 @@ public final class SearchTest {
                                                         .build();
 
     private final LocalServiceTestHelper helper =  new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+    private SampleData sample;
 
     private SearchServlet servlet;
 
@@ -67,7 +68,7 @@ public final class SearchTest {
     public void setUp() {
         helper.setUp();	  
 
-        SampleData sample = new SampleData();
+        sample = new SampleData();
         sample.addTutorsToDatastore();
 
         servlet = new SearchServlet();
@@ -97,14 +98,60 @@ public final class SearchTest {
         //verify that getParameter was called
         verify(request, times(1)).getParameter("topic"); 
         writer.flush(); // it may not have been flushed yet...
-        List<Tutor> expectedTutorList = Arrays.asList(new Tutor("Kashish Arora", "Kashish\'s bio", "images/pfp.jpg", "kashisharora@google.com", 
-                                                            new ArrayList<String> (Arrays.asList("math", "history")),
-                                                            new ArrayList<TimeRange> (Arrays.asList(TimeRange.fromStartToEnd(TIME_1200AM, TIME_0100PM, MAY182020),
-                                                                        TimeRange.fromStartToEnd(TIME_0300PM,TIME_0500PM, AUGUST102020))),
-                                                            new ArrayList<TutorSession> (Arrays.asList()), 0, 0, "0"));
+        List<Tutor> expectedTutorList = Arrays.asList(sample.getTutorByEmail("kashisharora@google.com"));
         String expected = new Gson().toJson(expectedTutorList);
-        System.out.println(stringWriter.toString());
-        System.out.println(expected);
+        Assert.assertTrue(stringWriter.toString().contains(expected));
+    }
+
+    @Test
+    public void testDefaultSortBy() throws IOException {
+        HttpServletRequest request = mock(HttpServletRequest.class);       
+        HttpServletResponse response = mock(HttpServletResponse.class); 
+        TestUtilities.setSessionId(request, "");
+
+        when(request.getParameter("topic")).thenReturn("english");
+
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter writer = new PrintWriter(stringWriter);
+        when(response.getWriter()).thenReturn(writer);
+
+        //create the hard coded data
+        servlet.doGet(request, response);
+
+        //verify that getParameter was called
+        verify(request, times(1)).getParameter("topic"); 
+        writer.flush(); // it may not have been flushed yet...
+        List<Tutor> expectedTutorList = Arrays.asList(sample.getTutorByEmail("btrevisan@google.com"), sample.getTutorByEmail("sfalberg@google.com"));
+        String expected = new Gson().toJson(expectedTutorList);
+        Assert.assertTrue(stringWriter.toString().contains(expected));
+    }
+
+    @Test
+    public void testSortByRating() throws IOException {
+        HttpServletRequest request = mock(HttpServletRequest.class);       
+        HttpServletResponse response = mock(HttpServletResponse.class); 
+        TestUtilities.setSessionId(request, "");
+
+        //rate Sam
+        sample.rateTutor("2", 5);
+
+        when(request.getParameter("topic")).thenReturn("english");
+        when(request.getParameter("sort-type")).thenReturn("rating");
+
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter writer = new PrintWriter(stringWriter);
+        when(response.getWriter()).thenReturn(writer);
+
+        //create the hard coded data
+        servlet.doGet(request, response);
+
+        //verify that getParameter was called
+        verify(request, times(1)).getParameter("topic"); 
+        verify(request, times(1)).getParameter("sort-type"); 
+        writer.flush(); // it may not have been flushed yet...
+        //Sam should be before Bernardo now
+        List<Tutor> expectedTutorList = Arrays.asList(sample.getTutorByEmail("sfalberg@google.com"), sample.getTutorByEmail("btrevisan@google.com"));
+        String expected = new Gson().toJson(expectedTutorList);
         Assert.assertTrue(stringWriter.toString().contains(expected));
     }
 


### PR DESCRIPTION
These commits add a filter list in the search results so users can sort by rating or names (alphabetically). I added a new property in the Tutor entity called "rating" that will keep track of the tutor's rating and allow us to get data from datastore that is already sorted by rating. I also added new tests for this feature and created a method in SampleData that will allow us to rate a tutor for testing. 