### PR TITLE
Correctly display the name of the tutor when the tutor is also a student

### DIFF
--- a/src/main/webapp/confirmation.js
+++ b/src/main/webapp/confirmation.js
@@ -67,8 +67,17 @@ async function createCalendar(scheduledSessions, container) {
         var date = (session.timeslot.date.month+1) + '/' + session.timeslot.date.dayOfMonth + '/' + session.timeslot.date.year;
 
         // Wait for this promise to resolve so tutor is defined when making calendar row
-        var tutor = await getUser(session.tutorID);
+        var tutorInfo = await getUser(session.tutorID);
         var description;
+        var tutor;
+
+        // If the tutor is also a student, get the information that relates to the tutor
+        if (tutorInfo.student != null) {
+            tutor = tutorInfo.tutor;
+        } else {
+            tutor = tutorInfo;
+        }
+
         if (session.subtopics == '') {
             description = "Tutoring session with " + tutor.name;
         } else {

--- a/src/main/webapp/manage-sessions.js
+++ b/src/main/webapp/manage-sessions.js
@@ -68,8 +68,17 @@ async function createCalendar(scheduledSessions, container) {
         var date = (session.timeslot.date.month+1) + '/' + session.timeslot.date.dayOfMonth + '/' + session.timeslot.date.year;
 
         // Wait for this promise to resolve so tutor is defined when making calendar row
-        var tutor = await getUser(session.tutorID);
+        var tutorInfo = await getUser(session.tutorID);
         var description;
+        var tutor;
+
+        // If the tutor is also a student, get the information that relates to the tutor
+        if (tutorInfo.student != null) {
+            tutor = tutorInfo.tutor;
+        } else {
+            tutor = tutorInfo;
+        }
+        
         if (session.subtopics == '') {
             description = "Tutoring session with " + tutor.name;
         } else {


### PR DESCRIPTION
The commits proposed in this PR fix the issue of a tutor having their name displayed as undefined when the tutor also had the role of a student. Changes include making sure to account for that type of user when displaying the user's name.