### PR TITLE
Only Display Future Availability

### DIFF
--- a/src/main/java/com/google/sps/data/SampleData.java
+++ b/src/main/java/com/google/sps/data/SampleData.java
@@ -57,14 +57,22 @@ public final class SampleData {
                                                         .setCalendarType("iso8601")
                                                         .setDate(2020, 7, 18)
                                                         .build();
+    private final Calendar NOV182020 = new Calendar.Builder()
+                                                        .setCalendarType("iso8601")
+                                                        .setDate(2020, 10, 18)
+                                                        .build();
+    private final Calendar DEC102020 = new Calendar.Builder()
+                                                        .setCalendarType("iso8601")
+                                                        .setDate(2020, 11, 10)
+                                                        .build();                
     //9 and 14 are the ids local datastore gives to these entities
     private final TutorSession bernardoSession = new TutorSession("1", "1", null, null, TimeRange.fromStartToEnd(540, 600, MAY182020), 9); 
     private final TutorSession samSession = new TutorSession("2", "2", null, null, TimeRange.fromStartToEnd(540, 600, AUGUST182020), 14);
 
     private ArrayList<Tutor> tutors = new ArrayList<Tutor> (Arrays.asList(
         new Tutor("Kashish Arora", "Kashish\'s bio", "images/pfp.jpg", "kashisharora@google.com", new ArrayList<String> (Arrays.asList("math", "history")),
-                new ArrayList<TimeRange> (Arrays.asList(TimeRange.fromStartToEnd(TIME_1200AM, TIME_0100PM, MAY182020),
-                            TimeRange.fromStartToEnd(TIME_0300PM,TIME_0500PM, AUGUST102020))),
+                new ArrayList<TimeRange> (Arrays.asList(TimeRange.fromStartToEnd(TIME_1200AM, TIME_0100PM, NOV182020),
+                            TimeRange.fromStartToEnd(TIME_0300PM,TIME_0500PM, DEC102020))),
                 new ArrayList<TutorSession> (Arrays.asList()), "0"),
         new Tutor("Bernardo Eilert Trevisan", "Bernardo\'s bio", "images/pfp.jpg", "btrevisan@google.com", new ArrayList<String> (Arrays.asList("english", "physics")),
                 new ArrayList<TimeRange> (Arrays.asList(TimeRange.fromStartToEnd(TIME_0800AM, TIME_1000AM, MAY182020),

--- a/src/main/java/com/google/sps/servlets/AvailabilityServlet.java
+++ b/src/main/java/com/google/sps/servlets/AvailabilityServlet.java
@@ -62,9 +62,32 @@ public class AvailabilityServlet extends HttpServlet {
 
         List<TimeRange> timeslots = datastore.getAvailabilityForTutor(tutorID);
 
-        String json = new Gson().toJson(timeslots);
+        List<TimeRange> upcomingTimeslots = filterUpcomingTimeslots(timeslots);
+
+        String json = new Gson().toJson(upcomingTimeslots);
         response.setContentType("application/json;");
         response.getWriter().println(json);
         return; 
+    }
+
+
+    /**
+    * Filters out time slots that are in the future.
+    * @return List<TimeRange>
+    */
+    private List<TimeRange> filterUpcomingTimeslots(List<TimeRange> allTimeslots) {
+        List<TimeRange> upcomingTimeslots = new ArrayList<TimeRange>();
+
+        Calendar currentCalendar = Calendar.getInstance();
+
+        for (TimeRange timeslot : allTimeslots) {
+            Calendar timeslotCalendar = timeslot.getDate();
+            int comparison = currentCalendar.compareTo(timeslotCalendar);
+            if (comparison == 0 || comparison == -1) {
+                    upcomingTimeslots.add(timeslot);
+            }
+        }
+
+        return upcomingTimeslots;
     }
 }

--- a/src/main/java/com/google/sps/servlets/ManageAvailabilityServlet.java
+++ b/src/main/java/com/google/sps/servlets/ManageAvailabilityServlet.java
@@ -53,7 +53,9 @@ public class ManageAvailabilityServlet extends HttpServlet {
 
         List<TimeRange> timeslots = datastore.getAvailabilityForTutor(tutorID);
 
-        String json = new Gson().toJson(timeslots);
+        List<TimeRange> upcomingTimeslots = filterUpcomingTimeslots(timeslots);
+
+        String json = new Gson().toJson(upcomingTimeslots);
         response.setContentType("application/json;");
         response.getWriter().println(json);
         return; 
@@ -95,5 +97,25 @@ public class ManageAvailabilityServlet extends HttpServlet {
         String json = new Gson().toJson(datastore.getAvailabilityForTutor(tutorID));
         response.getWriter().println(json);
         return;
+    }
+
+    /**
+    * Filters out time slots that are in the future.
+    * @return List<TimeRange>
+    */
+    private List<TimeRange> filterUpcomingTimeslots(List<TimeRange> allTimeslots) {
+        List<TimeRange> upcomingTimeslots = new ArrayList<TimeRange>();
+
+        Calendar currentCalendar = Calendar.getInstance();
+
+        for (TimeRange timeslot : allTimeslots) {
+            Calendar timeslotCalendar = timeslot.getDate();
+            int comparison = currentCalendar.compareTo(timeslotCalendar);
+            if (comparison == 0 || comparison == -1) {
+                    upcomingTimeslots.add(timeslot);
+            }
+        }
+
+        return upcomingTimeslots;
     }
 }

--- a/src/test/java/com/google/sps/AvailabilityTest.java
+++ b/src/test/java/com/google/sps/AvailabilityTest.java
@@ -44,13 +44,13 @@ public final class AvailabilityTest {
     private final int TIME_0100PM = TimeRange.getTimeInMinutes(13, 00);
     private final int TIME_0300PM = TimeRange.getTimeInMinutes(15, 00);
     private final int TIME_0500PM = TimeRange.getTimeInMinutes(17, 00);
-    private final Calendar MAY182020 = new Calendar.Builder()
+    private final Calendar NOV182020 = new Calendar.Builder()
                                                         .setCalendarType("iso8601")
-                                                        .setDate(2020, 4, 18)
+                                                        .setDate(2020, 10, 18)
                                                         .build();
-    private final Calendar AUGUST102020 = new Calendar.Builder()
+    private final Calendar DEC102020 = new Calendar.Builder()
                                                         .setCalendarType("iso8601")
-                                                        .setDate(2020, 7, 10)
+                                                        .setDate(2020, 11, 10)
                                                         .build();
     
     private final LocalServiceTestHelper helper =  new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
@@ -89,8 +89,8 @@ public final class AvailabilityTest {
       
         servlet.doGet(request, response);
 
-        String expected = new Gson().toJson(Arrays.asList(TimeRange.fromStartToEnd(TIME_1200AM, TIME_0100PM, MAY182020),
-                                                    TimeRange.fromStartToEnd(TIME_0300PM,TIME_0500PM, AUGUST102020)));
+        String expected = new Gson().toJson(Arrays.asList(TimeRange.fromStartToEnd(TIME_1200AM, TIME_0100PM, NOV182020),
+                                                    TimeRange.fromStartToEnd(TIME_0300PM,TIME_0500PM, DEC102020)));
 
         verify(request, times(1)).getParameter("tutorID");
         writer.flush();

--- a/src/test/java/com/google/sps/ManageAvailabilityTest.java
+++ b/src/test/java/com/google/sps/ManageAvailabilityTest.java
@@ -52,6 +52,14 @@ public final class ManageAvailabilityTest {
                                                         .setCalendarType("iso8601")
                                                         .setDate(2020, 7, 10)
                                                         .build();
+    private final Calendar NOV182020 = new Calendar.Builder()
+                                                        .setCalendarType("iso8601")
+                                                        .setDate(2020, 10, 18)
+                                                        .build();
+    private final Calendar DEC102020 = new Calendar.Builder()
+                                                        .setCalendarType("iso8601")
+                                                        .setDate(2020, 11, 10)
+                                                        .build();
 
     private final int TIME_1200AM = TimeRange.getTimeInMinutes(12, 00);
     private final int TIME_0100PM = TimeRange.getTimeInMinutes(13, 00);
@@ -95,8 +103,8 @@ public final class ManageAvailabilityTest {
       
         servlet.doGet(request, response);
 
-        String expected = new Gson().toJson(Arrays.asList(TimeRange.fromStartToEnd(TIME_1200AM, TIME_0100PM, MAY182020),
-                                                    TimeRange.fromStartToEnd(TIME_0300PM,TIME_0500PM, AUGUST102020)));
+        String expected = new Gson().toJson(Arrays.asList(TimeRange.fromStartToEnd(TIME_1200AM, TIME_0100PM, NOV182020),
+                                                    TimeRange.fromStartToEnd(TIME_0300PM,TIME_0500PM, DEC102020)));
 
         writer.flush();
         Assert.assertTrue(stringWriter.toString().contains(expected));
@@ -127,13 +135,13 @@ public final class ManageAvailabilityTest {
                                             .build();
 
         String expected = new Gson()
-                            .toJson(new ArrayList<TimeRange> (Arrays.asList(TimeRange.fromStartToEnd(TIME_1200AM, TIME_0100PM, MAY182020),
-                                                TimeRange.fromStartToEnd(TIME_0300PM,TIME_0500PM, AUGUST102020), 
+                            .toJson(new ArrayList<TimeRange> (Arrays.asList(TimeRange.fromStartToEnd(TIME_1200AM, TIME_0100PM, NOV182020),
+                                                TimeRange.fromStartToEnd(TIME_0300PM,TIME_0500PM, DEC102020), 
                                                 TimeRange.fromStartToEnd(TIME_1000PM,TIME_1100PM, expectedDate))));
 
         String unexpected = new Gson()
-                            .toJson(new ArrayList<TimeRange> (Arrays.asList(TimeRange.fromStartToEnd(TIME_1200AM, TIME_0100PM, MAY182020),
-                                                TimeRange.fromStartToEnd(TIME_0300PM,TIME_0500PM, AUGUST102020))));
+                            .toJson(new ArrayList<TimeRange> (Arrays.asList(TimeRange.fromStartToEnd(TIME_1200AM, TIME_0100PM, NOV182020),
+                                                TimeRange.fromStartToEnd(TIME_0300PM,TIME_0500PM, DEC102020))));
       
         writer.flush();
         // New available timeslot should have been added


### PR DESCRIPTION
The commits proposed in this PR make sure that only time slots in the future are displayed inside availability.html and inside manage-availability.html. Some of the unit tests had to be updated due to this change.