### PR TITLE
Delete available timeslots that bleed into next day

### DIFF
--- a/src/main/java/com/google/sps/servlets/DeleteAvailabilityServlet.java
+++ b/src/main/java/com/google/sps/servlets/DeleteAvailabilityServlet.java
@@ -40,12 +40,6 @@ public class DeleteAvailabilityServlet extends HttpServlet {
     }
 
     @Override
-    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        response.setContentType("plain/text");
-        response.getWriter().println("To be implemented");
-    }
-
-    @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         //if parameter is null, make the default id -1 so nothing gets deleted because there is no tutor with id = -1
         String tutorID = Optional.ofNullable((String)request.getSession(false).getAttribute("userId")).orElse("-1");


### PR DESCRIPTION
These commits will fix the issue where a tutor can't delete a timeslot that bleeds into the next day (i.e. 11:30pm - 12:30am). Changes include added logic in AvailabilityDatastoreService.java, and deletion of an unnecessary doGet function. 