### PR TITLE
Add Group Header

### DIFF
--- a/src/main/java/com/google/sps/servlets/GroupDataServlet.java
+++ b/src/main/java/com/google/sps/servlets/GroupDataServlet.java
@@ -1,0 +1,60 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import com.google.gson.Gson;
+import com.google.sps.data.Group;
+import com.google.sps.utilities.GroupDatastoreService;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** Servlet that retireves information for an specific group. */
+@WebServlet("/group-data")
+public class GroupDataServlet extends HttpServlet {
+    private GroupDatastoreService datastore;
+
+    public void init() {
+        datastore = new GroupDatastoreService();
+    }
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        String groupId = request.getParameter("groupId");
+
+        response.setContentType("application/json;");
+
+        // Send error message if the search was invalid.
+        if (groupId == null || groupId.equals("")) {
+            response.getWriter().println("{\"error\": \"Invalid group id.\"}");
+            return;
+        }
+
+        Group result = datastore.getGroupById(Long.parseLong(groupId));
+
+        response.setCharacterEncoding("UTF-8");
+
+        String json = new Gson().toJson(result);
+
+        response.getWriter().println(json);
+        return;
+    }
+}

--- a/src/main/java/com/google/sps/utilities/GroupDatastoreService.java
+++ b/src/main/java/com/google/sps/utilities/GroupDatastoreService.java
@@ -68,6 +68,26 @@ public final class GroupDatastoreService {
         return groups;
     }
 
+     /**
+    * Retrieves a group for the given group id.
+    */
+    public Group getGroupById(long groupId) {
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+        Key groupKey = KeyFactory.createKey("Group", groupId);
+
+        try {
+            Entity groupEntity = datastore.get(groupKey);
+            String name = (String) groupEntity.getProperty("name");
+            String topic = (String) groupEntity.getProperty("topic");
+            String description = (String) groupEntity.getProperty("description");
+            String owner = (String) groupEntity.getProperty("owner");
+
+            return new Group(name, topic, description, owner, groupId);
+        } catch (EntityNotFoundException e) {
+            return null;
+        }
+    }
+
     /**
     * Creates a new group.
     */

--- a/src/main/webapp/group.html
+++ b/src/main/webapp/group.html
@@ -20,7 +20,7 @@ See the License for the specific language governing permissions and
         <link rel="stylesheet" type="text/css" href="general.css">
         <link rel="stylesheet" type="text/css" href="group.css">
     </head>
-    <body onload="displayLoginLogoutLink(), addEventListeners(), displayGroupPosts()">
+    <body onload="displayLoginLogoutLink(), loadGroupHeader(), addEventListeners(), displayGroupPosts()">
         <nav class="navbar navbar-default navbar-fixed-top" id="top">
             <div class="container">
                 <div class="navbar-header">
@@ -61,7 +61,8 @@ See the License for the specific language governing permissions and
             </div>
         </nav>
 
-        <div class="container-fluid bg-white" id="group-header">
+        <div class="container-fluid bg-white">
+            <div id="group-header"></div>
             <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#new-post-modal" style="display:block">
                 + New Post
             </button>

--- a/src/main/webapp/group.js
+++ b/src/main/webapp/group.js
@@ -20,6 +20,43 @@ function addEventListeners() {
     });
 }
 
+/** A function that displays information about a group at the top of the group's page. */
+function loadGroupHeader() {
+    loadGroupHeaderHelper(document, window);
+}
+
+async function loadGroupHeaderHelper(document, window) {
+    const params = new URLSearchParams();
+
+    var queryString = new Array();
+    window.onload = readComponents(queryString, window);
+    const groupId = queryString["groupId"];
+
+    await fetch("/group-data?groupId=" + groupId).then(response => response.json()).then((result) => {
+        var groupHeaderContainer = document.getElementById("group-header");
+        
+        //if there was an error reported by the servlet, display the error message
+        if(result.error) {
+            groupHeaderContainer.innerText = result.error;
+            return;
+        }
+
+        var name = document.createElement("h1");
+        name.style.textTransform = 'capitalize';
+        var topic = document.createElement("h3");
+        topic.style.textTransform = 'capitalize';
+        var description = document.createElement("h4");
+
+        name.innerText = result.name;
+        topic.innerText = result.topic;
+        description.innerText = result.description;
+
+        groupHeaderContainer.appendChild(name);
+        groupHeaderContainer.appendChild(topic);
+        groupHeaderContainer.appendChild(description);
+    });
+}
+
 function addPost(window) {
     const params = new URLSearchParams();
 
@@ -54,14 +91,14 @@ async function displayGroupPostsHelper(document, window) {
     var groupId = queryString["groupId"];
 
     if(groupId != null) {
-        var posts = getPosts(groupId);
+        var posts = getPosts(groupId, document);
         
         await posts;
     }
 }
 
 /** Fetches the posts connected with the given group id. */
-async function getPosts(groupId) {
+async function getPosts(groupId, document) {
     await fetch("/manage-posts?groupId=" + groupId).then(response => response.json()).then((results) => {
         var postsContainer = document.getElementById("posts");
 
@@ -80,14 +117,14 @@ async function getPosts(groupId) {
         numSearchResults.innerText = "Found " + results.length + (results.length > 1 || results.length === 0 ? " posts for this group" : " post for this group");
 
         results.forEach(function(result) {
-            postsContainer.append(createPostResult(result));
+            postsContainer.append(createPostResult(result, document));
         });
     });
 
 }
 
 /** Creates a div element containing information about a post result. */
-function createPostResult(result) {
+function createPostResult(result, document) {
     var container = document.createElement("div");
     var name = document.createElement("h5");
     name.style.textTransform = 'capitalize';
@@ -95,6 +132,7 @@ function createPostResult(result) {
     var replyForm = document.createElement("form");
     var replyInput = document.createElement("input");
     var replySubmit = document.createElement("button");
+    var br = document.createElement("br");
     var viewThread = document.createElement("button");
 
     if (result.userID != "anonymous") {
@@ -134,7 +172,7 @@ function createPostResult(result) {
     viewThread.className = "btn btn-outline-success my-2 my-sm-0";
     viewThread.innerText = "View Thread";
     viewThread.addEventListener('click', () => {
-        displayThread(result, container);
+        displayThread(result, container, document);
     });
    
 
@@ -144,6 +182,7 @@ function createPostResult(result) {
     container.appendChild(content);
     container.appendChild(name);
     container.appendChild(replyForm);
+    container.appendChild(br);
     container.appendChild(viewThread);
 
     return container;

--- a/src/main/webapp/group.js
+++ b/src/main/webapp/group.js
@@ -25,14 +25,14 @@ function loadGroupHeader() {
     loadGroupHeaderHelper(document, window);
 }
 
-async function loadGroupHeaderHelper(document, window) {
+function loadGroupHeaderHelper(document, window) {
     const params = new URLSearchParams();
 
     var queryString = new Array();
     window.onload = readComponents(queryString, window);
     const groupId = queryString["groupId"];
 
-    await fetch("/group-data?groupId=" + groupId).then(response => response.json()).then((result) => {
+    fetch("/group-data?groupId=" + groupId).then(response => response.json()).then((result) => {
         var groupHeaderContainer = document.getElementById("group-header");
         
         //if there was an error reported by the servlet, display the error message
@@ -54,6 +54,9 @@ async function loadGroupHeaderHelper(document, window) {
         groupHeaderContainer.appendChild(name);
         groupHeaderContainer.appendChild(topic);
         groupHeaderContainer.appendChild(description);
+
+        // Returned for testing purposes
+        return groupHeaderContainer;
     });
 }
 

--- a/src/main/webapp/webapptests/spec/SpecGroup.js
+++ b/src/main/webapp/webapptests/spec/SpecGroup.js
@@ -30,6 +30,23 @@ describe("Single Group", function() {
         });
     });
 
+    describe("when the group header is loaded", function() {
+        var mockWindow = {location: {href: "group.html?groupId=123", search: "?groupId=123"}};
+
+        it("should trigger the fetch function with the correct params and display the correct header", function() {
+            var result = {"name": "test", "topic": "test", "description": "test"}
+            spyOn(window, 'fetch').and.returnValue(Promise.resolve({json: () => Promise.resolve(result)}));
+            var headerContainer = await loadGroupHeaderHelper(mockWindow, document);
+            expect(window.fetch).toHaveBeenCalledWith('/group-data?groupId=undefined');
+            expect(headerContainer.childNodes[0].tagName).toEqual("H1");
+            expect(headerContainer.childNodes[0].innerText).toContain("test");
+            expect(headerContainer.childNodes[1].tagName).toEqual("H3");
+            expect(headerContainer.childNodes[1].innerText).toContain("test");
+            expect(headerContainer.childNodes[2].tagName).toEqual("H4");
+            expect(headerContainer.childNodes[2].innerText).toContain("test");
+        });
+    });
+
     describe("when posts are displayed", function() {
         var posts = [{"userID": "anonymous", "groupID": "321", "content": "test", "id": "1"}, 
                         {"userID": "anonymous", "groupID": "321", "content": "test", "id": "3"}];
@@ -58,7 +75,7 @@ describe("Single Group", function() {
 
     describe("when a post result is created", function() {
         var result = {"userID": "anonymous", "content": "test"};
-        var element = createPostResult(result);
+        var element = createPostResult(result, document);
 
         it("should create div for result element", function() {
             expect(element.tagName).toEqual("DIV");
@@ -84,9 +101,13 @@ describe("Single Group", function() {
             expect(element.childNodes[2].childNodes[1].innerText).toContain("Submit");
         });
 
+        it("should create break element inside result element", function() {
+            expect(element.childNodes[3].tagName).toEqual("BR");
+        });
+
         it("should create button element inside result element for viewing a thread", function() {
-            expect(element.childNodes[3].tagName).toEqual("BUTTON");
-            expect(element.childNodes[3].innerText).toContain("View Thread");
+            expect(element.childNodes[4].tagName).toEqual("BUTTON");
+            expect(element.childNodes[4].innerText).toContain("View Thread");
         });
 
     });

--- a/src/test/java/com/google/sps/GroupDataTest.java
+++ b/src/test/java/com/google/sps/GroupDataTest.java
@@ -1,0 +1,155 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps;
+
+import com.google.utilities.TestUtilities;
+import java.io.StringWriter;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.After;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import static org.mockito.Mockito.*;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.*;
+import com.google.sps.servlets.GroupDataServlet;
+import com.google.sps.data.Group;
+import com.google.gson.Gson;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+
+@RunWith(JUnit4.class)
+public final class GroupDataTest {
+
+    private final LocalServiceTestHelper helper =  new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig()); 
+
+    private GroupDataServlet servlet;
+
+    @Before
+    public void setUp() {
+        helper.setUp();
+
+        servlet = new GroupDataServlet();
+        servlet.init();
+
+    }
+
+    @After
+    public void tearDown() {
+        helper.tearDown();
+    }
+
+    @Test
+    public void testDoGetWithNoResults() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);       
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        // Adds group entity to the local datastore that will not match the query
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+        Entity groupEntity = new Entity("Group");
+        groupEntity.setProperty("name", "real");
+        groupEntity.setProperty("topic", "math");
+        groupEntity.setProperty("description", "");
+        groupEntity.setProperty("owner", "123");
+        datastore.put(groupEntity);
+
+        when(request.getParameter("groupId")).thenReturn("2");
+
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter writer = new PrintWriter(stringWriter);
+        when(response.getWriter()).thenReturn(writer);
+        when(request.getContentType()).thenReturn("application/json");
+
+        servlet.doGet(request, response);
+
+        verify(request, times(1)).getParameter("groupId");
+      
+        writer.flush();
+
+        String expected = new Gson()
+                            .toJson(null);
+ 
+        // No groups should have been returned
+        Assert.assertTrue(stringWriter.toString().contains(expected));
+    }
+
+    @Test
+    public void testDoGetWithResults() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);       
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        // Adds group entity to the local datastore
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+        Entity groupEntity = new Entity("Group");
+        groupEntity.setProperty("name", "test");
+        groupEntity.setProperty("topic", "math");
+        groupEntity.setProperty("description", "");
+        groupEntity.setProperty("owner", "123");
+        datastore.put(groupEntity);
+
+        when(request.getParameter("groupId")).thenReturn("1");
+
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter writer = new PrintWriter(stringWriter);
+        when(response.getWriter()).thenReturn(writer);
+        when(request.getContentType()).thenReturn("application/json");
+
+        servlet.doGet(request, response);
+
+        verify(request, times(1)).getParameter("groupId");
+
+        String expected = new Gson()
+                            .toJson(new Group("test", "math", "", "123", 1));
+      
+        writer.flush();
+
+        // The correct list of experiences should have been returned
+        Assert.assertTrue(stringWriter.toString().contains(expected));
+    }
+
+    @Test
+    public void testDoGetWithError() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);       
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        when(request.getParameter("groupId")).thenReturn(null);
+
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter writer = new PrintWriter(stringWriter);
+        when(response.getWriter()).thenReturn(writer);
+        when(request.getContentType()).thenReturn("application/json");
+
+        servlet.doGet(request, response);
+
+        verify(request, times(1)).getParameter("groupId");
+
+        String expected = "{\"error\": \"Invalid group id.\"}";
+      
+        writer.flush();
+
+        // Error should have been returned
+        Assert.assertTrue(stringWriter.toString().contains(expected));
+    }
+}


### PR DESCRIPTION
The commits proposed int his PR load the group header when that group's page is viewed. Changes include adding a servlet that gets information about a group given its id and adding a loadGroupHeader function to group.js. Java and Jasmine tests have also been added