### PR TITLE
Center Error Message in History

### DIFF
--- a/src/main/webapp/history.js
+++ b/src/main/webapp/history.js
@@ -44,6 +44,7 @@ function getTutoringSessionHistoryHelper(window) {
         } else {
             var historyContainer = document.getElementById('tutoringSessionHistory');
             var errorMessage = document.createElement("p");
+            errorMessage.className = "text-center";
             errorMessage.innerText = "This user does not have any tutoring session history.";
             historyContainer.appendChild(errorMessage);
             return;


### PR DESCRIPTION
The commit proposed in this PR updates the class given to the error message inside the history page for when a tutor does not have any tutoring session history so that it is centered.