### PR TITLE
Remove color-coding for different rows on calendar

### DIFF
--- a/src/main/webapp/availability.js
+++ b/src/main/webapp/availability.js
@@ -77,6 +77,7 @@ function createCalendar(timeslots, tutorID, container) {
     const options = {
         width: 1000,
         height: 300,
+        timeline: { singleColor: '#437f97' },
         hAxis: {
             minValue: min,
             maxValue: max

--- a/src/main/webapp/confirmation.js
+++ b/src/main/webapp/confirmation.js
@@ -98,6 +98,7 @@ async function createCalendar(scheduledSessions, container) {
     const options = {
         width: 1000,
         height: 300,
+        timeline: { singleColor: '#437f97' },
         hAxis: {
             minValue: min,
             maxValue: max

--- a/src/main/webapp/manage-availability.js
+++ b/src/main/webapp/manage-availability.js
@@ -163,6 +163,7 @@ function createCalendar(timeslots, container) {
     const options = {
         width: 1000,
         height: 300,
+        timeline: { singleColor: '#437f97' },
         hAxis: {
             minValue: min,
             maxValue: max

--- a/src/main/webapp/manage-sessions.js
+++ b/src/main/webapp/manage-sessions.js
@@ -102,6 +102,7 @@ async function createCalendar(scheduledSessions, container) {
     const options = {
         width: 1000,
         height: 300,
+        timeline: { singleColor: '#437f97' },
         hAxis: {
             minValue: min,
             maxValue: max


### PR DESCRIPTION
These commits will change the calendar so sessions are always displayed as the same color regardless of what row they're on.