### PR TITLE
Updates Display of Lists and Availability in Profile

### DIFF
--- a/src/main/webapp/profile.js
+++ b/src/main/webapp/profile.js
@@ -113,6 +113,18 @@ function fetchStatusHelper(user, loginStatus, window, document) {
             "I am tutoring in: " + listWithSpacesTutor;
 
         loadProgress(document, loginStatus, user);
+
+        getListsProfile();
+
+        // Only students should be allowed to schedule sessions with tutors from their profile
+        if (role == 'student' || role == 'both') {
+            document.getElementById('tutor-availability').style.display = 'block';
+            document.getElementById('tutor-availability-btn').addEventListener('click', () => {
+                redirectToAvailability(user, window); 
+            });
+        } else {
+            document.getElementById('tutor-availability').style.display = 'none';
+        }
         
          // If the user is only a student
     } else if (user.learning != null) { // Display topics as comma-separated list with spaces

--- a/src/main/webapp/webapptests/spec/SpecProfile.js
+++ b/src/main/webapp/webapptests/spec/SpecProfile.js
@@ -21,6 +21,7 @@ describe("User Profile", function() {
             email: "sfalberg@google.com", skills: ["Math", "Physics"]};
         var mockLoginStatusTutor = {role:"tutor", userId: "123"};
         var mockLoginStatusStudent = {role:"student", userId: "abc"};
+        var mockLoginStatusBoth = {role:"both", userId: "abc"};
  
         beforeAll(function() {
             var mockEditButton = document.createElement('btn');
@@ -30,12 +31,17 @@ describe("User Profile", function() {
             var mockAvailability = document.createElement('div');
             mockAvailability.style.display = 'none';
             mockAvailability.id = "tutor-availability";
+
+            var mockTutorLists = document.createElement("div");
+            mockTutorLists.style.display = 'none';
+            mockTutorLists.id = "list-container-profile";
  
             var mockAvailabilityButton = document.createElement('btn');
             mockAvailabilityButton.id = "tutor-availability-btn";
  
             document.body.appendChild(mockEditButton);
             document.body.appendChild(mockAvailability);
+            document.body.appendChild(mockTutorLists);
             document.body.appendChild(mockAvailabilityButton);
             
             spyOn(window, 'addEventListeners');
@@ -106,6 +112,11 @@ describe("User Profile", function() {
  
         it("should set make the tutor availability button visible if current user is a student", function() {
             fetchStatusHelper(mockUser, mockLoginStatusStudent, mockWindow, document);
+            expect(document.getElementById('tutor-availability').style.display).toBe('block');
+        });
+
+        it("should set make the tutor availability button visible if current user is a both", function() {
+            fetchStatusHelper(mockUser, mockLoginStatusBoth, mockWindow, document);
             expect(document.getElementById('tutor-availability').style.display).toBe('block');
         });
 


### PR DESCRIPTION
The commit proposed in this PR updates the display of book lists and tutor availability in profile page so that they are compatible with the "both" role. Before the user was not able to see the lists or availability of a tutor if that tutor was also a student. It should be good now. I also updated the tests.